### PR TITLE
chore: corrige alertas apontados no OWASP ZAP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+<<<<<<< HEAD
                 "@aws-sdk/client-sqs": "^3.521.0",
                 "aws-sdk": "^2.1565.0",
                 "axios": "^1.5.0",
@@ -17,6 +18,15 @@
                 "mongoose": "^7.2.3",
                 "postgres": "^3.4.2",
                 "sqs-consumer": "^8.2.0",
+=======
+                "axios": "^1.5.0",
+                "express": "^4.18.2",
+                "express-async-errors": "^3.1.1",
+                "helmet": "^7.1.0",
+                "mongoose": "^7.2.3",
+                "nocache": "^4.0.0",
+                "postgres": "^3.4.2",
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
                 "swagger-ui-express": "^4.6.3"
             },
             "devDependencies": {
@@ -59,6 +69,7 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+<<<<<<< HEAD
             }
         },
         "node_modules/@aws-crypto/crc32": {
@@ -772,6 +783,10 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
+=======
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@babel/code-frame": {
             "version": "7.22.5",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
@@ -1014,6 +1029,7 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+<<<<<<< HEAD
             }
         },
         "node_modules/@babel/highlight/node_modules/ansi-styles": {
@@ -1111,6 +1127,105 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+=======
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.22.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
+            "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@babel/plugin-syntax-bigint": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
@@ -1844,6 +1959,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
+<<<<<<< HEAD
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -1913,6 +2029,77 @@
                 "node": ">=8"
             }
         },
+=======
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -2050,6 +2237,7 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+<<<<<<< HEAD
             }
         },
         "node_modules/@jest/globals": {
@@ -3063,6 +3251,289 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
+=======
+            }
+        },
+        "node_modules/@jest/globals": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
+            "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^29.6.1",
+                "@jest/expect": "^29.6.1",
+                "@jest/types": "^29.6.1",
+                "jest-mock": "^29.6.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/reporters": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
+            "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
+            "dev": true,
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^29.6.1",
+                "@jest/test-result": "^29.6.1",
+                "@jest/transform": "^29.6.1",
+                "@jest/types": "^29.6.1",
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^5.1.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.1.3",
+                "jest-message-util": "^29.6.1",
+                "jest-util": "^29.6.1",
+                "jest-worker": "^29.6.1",
+                "slash": "^3.0.0",
+                "string-length": "^4.0.1",
+                "strip-ansi": "^6.0.0",
+                "v8-to-istanbul": "^9.0.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jest/schemas": {
+            "version": "29.6.0",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+            "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+            "dev": true,
+            "dependencies": {
+                "@sinclair/typebox": "^0.27.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/source-map": {
+            "version": "29.6.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.0.tgz",
+            "integrity": "sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.9"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/test-result": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
+            "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^29.6.1",
+                "@jest/types": "^29.6.1",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/test-sequencer": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
+            "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/test-result": "^29.6.1",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.6.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/transform": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+            "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@jest/types": "^29.6.1",
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "babel-plugin-istanbul": "^6.1.1",
+                "chalk": "^4.0.0",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.6.1",
+                "jest-regex-util": "^29.4.3",
+                "jest-util": "^29.6.1",
+                "micromatch": "^4.0.4",
+                "pirates": "^4.0.4",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^4.0.2"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/types": {
+            "version": "29.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+            "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/schemas": "^29.6.0",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "3.1.0",
+                "@jridgewell/sourcemap-codec": "1.4.14"
+            }
+        },
+        "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.14",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
+        },
+        "node_modules/@nicolo-ribaudo/semver-v6": {
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
+            "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@sinclair/typebox": {
+            "version": "0.27.8",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "dev": true
+        },
+        "node_modules/@sinonjs/commons": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+            "dev": true,
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.0"
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -3692,6 +4163,7 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
+<<<<<<< HEAD
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3734,6 +4206,8 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/axios": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
@@ -3841,6 +4315,7 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+<<<<<<< HEAD
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3860,6 +4335,8 @@
                 }
             ]
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3905,11 +4382,14 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
+<<<<<<< HEAD
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3992,6 +4472,7 @@
             "engines": {
                 "node": ">=14.20.1"
             }
+<<<<<<< HEAD
         },
         "node_modules/buffer": {
             "version": "4.9.2",
@@ -4002,6 +4483,8 @@
                 "ieee754": "^1.1.4",
                 "isarray": "^1.0.0"
             }
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -4018,6 +4501,7 @@
             }
         },
         "node_modules/call-bind": {
+<<<<<<< HEAD
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
             "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
@@ -4030,6 +4514,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
+=======
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4371,6 +4863,7 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+<<<<<<< HEAD
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -4387,6 +4880,8 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -4537,6 +5032,7 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+<<<<<<< HEAD
         "node_modules/es-define-property": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -4556,6 +5052,8 @@
                 "node": ">= 0.4"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/esbuild": {
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
@@ -4821,6 +5319,7 @@
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "engines": {
                 "node": ">= 0.6"
+<<<<<<< HEAD
             }
         },
         "node_modules/events": {
@@ -4829,6 +5328,8 @@
             "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
             "engines": {
                 "node": ">=0.4.x"
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/execa": {
@@ -5014,6 +5515,7 @@
             },
             "engines": {
                 "node": ">=4"
+<<<<<<< HEAD
             }
         },
         "node_modules/express/node_modules/debug": {
@@ -5024,6 +5526,18 @@
                 "ms": "2.0.0"
             }
         },
+=======
+            }
+        },
+        "node_modules/express/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/express/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5075,6 +5589,7 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+<<<<<<< HEAD
         "node_modules/fast-xml-parser": {
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
@@ -5096,6 +5611,8 @@
                 "fxparser": "src/cli/cli.js"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/fastq": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -5233,6 +5750,7 @@
                     "optional": true
                 }
             }
+<<<<<<< HEAD
         },
         "node_modules/for-each": {
             "version": "0.3.3",
@@ -5241,6 +5759,8 @@
             "dependencies": {
                 "is-callable": "^1.1.3"
             }
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/form-data": {
             "version": "4.0.0",
@@ -5292,12 +5812,18 @@
             }
         },
         "node_modules/function-bind": {
+<<<<<<< HEAD
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+=======
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -5318,6 +5844,7 @@
             }
         },
         "node_modules/get-intrinsic": {
+<<<<<<< HEAD
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
             "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
@@ -5330,6 +5857,16 @@
             },
             "engines": {
                 "node": ">= 0.4"
+=======
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3"
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5435,6 +5972,7 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+<<<<<<< HEAD
         "node_modules/gopd": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5446,6 +5984,8 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5462,7 +6002,10 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+<<<<<<< HEAD
             "dev": true,
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -5478,6 +6021,7 @@
             "engines": {
                 "node": ">=8"
             }
+<<<<<<< HEAD
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
@@ -5489,6 +6033,8 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/has-proto": {
             "version": "1.0.1",
@@ -5512,6 +6058,7 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+<<<<<<< HEAD
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
@@ -5535,6 +6082,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
+=======
+        "node_modules/helmet": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+            "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+            "engines": {
+                "node": ">=16.0.0"
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/html-escaper": {
@@ -5578,11 +6133,14 @@
                 "node": ">=0.10.0"
             }
         },
+<<<<<<< HEAD
         "node_modules/ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/ignore": {
             "version": "5.2.4",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -5663,6 +6221,7 @@
             "engines": {
                 "node": ">= 0.10"
             }
+<<<<<<< HEAD
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
@@ -5678,6 +6237,8 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -5695,6 +6256,7 @@
             },
             "engines": {
                 "node": ">=8"
+<<<<<<< HEAD
             }
         },
         "node_modules/is-callable": {
@@ -5706,6 +6268,8 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/is-core-module": {
@@ -5747,6 +6311,7 @@
                 "node": ">=6"
             }
         },
+<<<<<<< HEAD
         "node_modules/is-generator-function": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
@@ -5761,6 +6326,8 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5802,6 +6369,7 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+<<<<<<< HEAD
         },
         "node_modules/is-typed-array": {
             "version": "1.1.13",
@@ -5822,6 +6390,9 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
+=======
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6457,6 +7028,7 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
+<<<<<<< HEAD
             }
         },
         "node_modules/jmespath": {
@@ -6465,6 +7037,8 @@
             "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
             "engines": {
                 "node": ">= 0.6.0"
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/js-tokens": {
@@ -6923,6 +7497,17 @@
             "engines": {
                 "node": ">= 0.6"
             }
+<<<<<<< HEAD
+=======
+        },
+        "node_modules/nocache": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/nocache/-/nocache-4.0.0.tgz",
+            "integrity": "sha512-AntnTbmKZvNYIsTVPPwv7dfZdAfo/6H/2ZlZACK66NAOQtIApxkB/6pf/c+s+ACW8vemGJzUCyVTssrzNUK6yQ==",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
@@ -7227,6 +7812,7 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+<<<<<<< HEAD
             }
         },
         "node_modules/pkg-dir/node_modules/p-locate": {
@@ -7241,6 +7827,22 @@
                 "node": ">=8"
             }
         },
+=======
+            }
+        },
+        "node_modules/pkg-dir/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/plimit-lit": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.5.0.tgz",
@@ -7250,6 +7852,7 @@
                 "queue-lit": "^1.5.0"
             }
         },
+<<<<<<< HEAD
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -7270,6 +7873,20 @@
                 "url": "https://github.com/sponsors/porsager"
             }
         },
+=======
+        "node_modules/postgres": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.2.tgz",
+            "integrity": "sha512-0UcCGvDBSaAzLeWwiq+QVmiGfOPTosFb+sxJUUtd+7Pi/ByFPuz6Gq05LbS0sM1ghMWC5atuks3pfl34g0qmFw==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/porsager"
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7373,6 +7990,7 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+<<<<<<< HEAD
         "node_modules/querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -7382,6 +8000,8 @@
                 "node": ">=0.4.x"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/queue-lit": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.0.tgz",
@@ -7629,11 +8249,14 @@
                 "node": ">=6"
             }
         },
+<<<<<<< HEAD
         "node_modules/sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/semver": {
             "version": "7.5.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
@@ -7720,6 +8343,7 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+<<<<<<< HEAD
             }
         },
         "node_modules/set-function-length": {
@@ -7736,6 +8360,8 @@
             },
             "engines": {
                 "node": ">= 0.4"
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/setprototypeof": {
@@ -7874,6 +8500,7 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true
         },
+<<<<<<< HEAD
         "node_modules/sqs-consumer": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-8.2.0.tgz",
@@ -7889,6 +8516,8 @@
                 "@aws-sdk/client-sqs": "^3.447.0"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -7908,6 +8537,7 @@
             },
             "engines": {
                 "node": ">=10"
+<<<<<<< HEAD
             }
         },
         "node_modules/stack-utils/node_modules/escape-string-regexp": {
@@ -7919,6 +8549,19 @@
                 "node": ">=8"
             }
         },
+=======
+            }
+        },
+        "node_modules/stack-utils/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/statuses": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -8004,11 +8647,14 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+<<<<<<< HEAD
         },
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
             "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -8508,6 +9154,7 @@
                 "punycode": "^2.1.0"
             }
         },
+<<<<<<< HEAD
         "node_modules/url": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -8534,6 +9181,8 @@
                 "which-typed-array": "^1.1.2"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8548,6 +9197,7 @@
                 "node": ">= 0.4.0"
             }
         },
+<<<<<<< HEAD
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -8556,6 +9206,8 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -8632,6 +9284,7 @@
             },
             "engines": {
                 "node": ">= 8"
+<<<<<<< HEAD
             }
         },
         "node_modules/which-typed-array": {
@@ -8650,6 +9303,8 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/winston": {
@@ -8722,6 +9377,7 @@
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+<<<<<<< HEAD
             }
         },
         "node_modules/xml2js": {
@@ -8742,6 +9398,8 @@
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "engines": {
                 "node": ">=4.0"
+=======
+>>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -788,15 +788,87 @@
         },
 >>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@babel/code-frame": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-            "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.22.5"
+                "@babel/highlight": "^7.23.4",
+                "chalk": "^2.4.2"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@babel/compat-data": {
@@ -845,12 +917,12 @@
             "dev": true
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.7.tgz",
-            "integrity": "sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5",
+                "@babel/types": "^7.23.6",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -879,22 +951,22 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -977,18 +1049,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+            "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -1018,13 +1090,13 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-            "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.5",
-                "chalk": "^2.0.0",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             },
             "engines": {
@@ -1104,9 +1176,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-            "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.0.tgz",
+            "integrity": "sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1392,34 +1464,34 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-            "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.8",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-            "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.0.tgz",
+            "integrity": "sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/generator": "^7.22.7",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.23.5",
+                "@babel/generator": "^7.23.6",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.7",
-                "@babel/types": "^7.22.5",
-                "debug": "^4.1.0",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -1436,13 +1508,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-            "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+            "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -3465,6 +3537,15 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
             "dev": true
         },
+        "node_modules/@mongodb-js/saslprep": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
+            "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
+            "optional": true,
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
+            }
+        },
         "node_modules/@nicolo-ribaudo/semver-v6": {
             "version": "6.3.3",
             "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
@@ -3788,9 +3869,9 @@
             "dev": true
         },
         "node_modules/@types/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
         },
         "node_modules/@types/whatwg-url": {
             "version": "8.2.2",
@@ -4209,11 +4290,11 @@
 =======
 >>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/axios": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-            "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
             "dependencies": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.4",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -4466,9 +4547,9 @@
             }
         },
         "node_modules/bson": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-            "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+            "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
             "engines": {
                 "node": ">=14.20.1"
             }
@@ -5733,9 +5814,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "funding": [
                 {
                     "type": "individual",
@@ -6209,10 +6290,22 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
-        "node_modules/ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ip-address/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
@@ -6425,9 +6518,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -7059,6 +7152,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
         "node_modules/jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7224,9 +7322,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -7375,11 +7473,11 @@
             }
         },
         "node_modules/mongodb": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.6.0.tgz",
-            "integrity": "sha512-z8qVs9NfobHJm6uzK56XBZF8XwM9H294iRnB7wNjF0SnY93si5HPziIJn+qqvUR5QOff/4L0gCD6SShdR/GtVQ==",
+            "version": "5.9.1",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.1.tgz",
+            "integrity": "sha512-NBGA8AfJxGPeB12F73xXwozt8ZpeIPmCUeWRwl9xejozTXFes/3zaep9zhzs1B/nKKsw4P3I4iPfXl3K7s6g+Q==",
             "dependencies": {
-                "bson": "^5.3.0",
+                "bson": "^5.5.0",
                 "mongodb-connection-string-url": "^2.6.0",
                 "socks": "^2.7.1"
             },
@@ -7387,15 +7485,23 @@
                 "node": ">=14.20.1"
             },
             "optionalDependencies": {
-                "saslprep": "^1.0.3"
+                "@mongodb-js/saslprep": "^1.1.0"
             },
             "peerDependencies": {
-                "@aws-sdk/credential-providers": "^3.201.0",
+                "@aws-sdk/credential-providers": "^3.188.0",
+                "@mongodb-js/zstd": "^1.0.0",
+                "kerberos": "^1.0.0 || ^2.0.0",
                 "mongodb-client-encryption": ">=2.3.0 <3",
                 "snappy": "^7.2.2"
             },
             "peerDependenciesMeta": {
                 "@aws-sdk/credential-providers": {
+                    "optional": true
+                },
+                "@mongodb-js/zstd": {
+                    "optional": true
+                },
+                "kerberos": {
                     "optional": true
                 },
                 "mongodb-client-encryption": {
@@ -7416,13 +7522,13 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "7.3.2",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.3.2.tgz",
-            "integrity": "sha512-Z86m5ASwYYFyT++wPQTtuTl5Jh052w6G1IM8LxPu/6iuqxQo6nUOaEoGZfMy0ovw3Dyw3415Jue3pYXkRqPkfA==",
+            "version": "7.6.9",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.9.tgz",
+            "integrity": "sha512-3lR1fA/gS1E9Bn0woFqIysnnjCFDYtVo3yY+rGsVg1Q7kHX+gUTgAHTEKXrkwKxk2gHFdUfAsLt/Zjrdf6+nZA==",
             "dependencies": {
-                "bson": "^5.3.0",
+                "bson": "^5.5.0",
                 "kareem": "2.5.1",
-                "mongodb": "5.6.0",
+                "mongodb": "5.9.1",
                 "mpath": "0.9.0",
                 "mquery": "5.0.0",
                 "ms": "2.1.3",
@@ -8237,6 +8343,7 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
+<<<<<<< HEAD
         "node_modules/saslprep": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
@@ -8257,6 +8364,8 @@
         },
 =======
 >>>>>>> chore: corrige alertas apontados no OWASP ZAP
+=======
+>>>>>>> chore: ajusta vulnerabilidades apontadas no npm
         "node_modules/semver": {
             "version": "7.5.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
@@ -8454,15 +8563,15 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
+            "integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,8 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-<<<<<<< HEAD
                 "@aws-sdk/client-sqs": "^3.521.0",
                 "aws-sdk": "^2.1565.0",
-                "axios": "^1.5.0",
-                "express": "^4.18.2",
-                "express-async-errors": "^3.1.1",
-                "mongoose": "^7.2.3",
-                "postgres": "^3.4.2",
-                "sqs-consumer": "^8.2.0",
-=======
                 "axios": "^1.5.0",
                 "express": "^4.18.2",
                 "express-async-errors": "^3.1.1",
@@ -26,7 +18,7 @@
                 "mongoose": "^7.2.3",
                 "nocache": "^4.0.0",
                 "postgres": "^3.4.2",
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
+                "sqs-consumer": "^8.2.0",
                 "swagger-ui-express": "^4.6.3"
             },
             "devDependencies": {
@@ -59,17 +51,16 @@
             }
         },
         "node_modules/@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
-<<<<<<< HEAD
             }
         },
         "node_modules/@aws-crypto/crc32": {
@@ -82,6 +73,11 @@
                 "tslib": "^1.11.1"
             }
         },
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -89,6 +85,11 @@
             "dependencies": {
                 "tslib": "^1.11.1"
             }
+        },
+        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "3.0.0",
@@ -105,6 +106,11 @@
                 "tslib": "^1.11.1"
             }
         },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
@@ -115,6 +121,11 @@
                 "tslib": "^1.11.1"
             }
         },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
@@ -122,6 +133,11 @@
             "dependencies": {
                 "tslib": "^1.11.1"
             }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/util": {
             "version": "3.0.0",
@@ -133,16 +149,21 @@
                 "tslib": "^1.11.1"
             }
         },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
         "node_modules/@aws-sdk/client-sqs": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.525.0.tgz",
-            "integrity": "sha512-a38nL1/jnPzUkAvYMSPKJFfJFppGs6aaxUXIuYYEDns6DvIrnXNKljAA8FBrCqWZ8D5SScB2sit3nRYhGN2b4A==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.529.1.tgz",
+            "integrity": "sha512-TBQWhf/9tWw5b6xZ0l9TtQUyB8WVIOmS4t6enr6zWsf/MJ9rjEcGJh6gyoF71URL2Bv5/x7qzLVPzxT/NRE+Ag==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.525.0",
-                "@aws-sdk/core": "3.525.0",
-                "@aws-sdk/credential-provider-node": "3.525.0",
+                "@aws-sdk/client-sts": "3.529.1",
+                "@aws-sdk/core": "3.529.1",
+                "@aws-sdk/credential-provider-node": "3.529.1",
                 "@aws-sdk/middleware-host-header": "3.523.0",
                 "@aws-sdk/middleware-logger": "3.523.0",
                 "@aws-sdk/middleware-recursion-detection": "3.523.0",
@@ -185,19 +206,14 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sqs/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.525.0.tgz",
-            "integrity": "sha512-6KwGQWFoNLH1UupdWPFdKPfTgjSz1kN8/r8aCzuvvXBe4Pz+iDUZ6FEJzGWNc9AapjvZDNO1hs23slomM9rTaA==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.529.1.tgz",
+            "integrity": "sha512-KT1U/ZNjDhVv2ZgjzaeAn9VM7l667yeSguMrRYC8qk5h91/61MbjZypi6eOuKuVM+0fsQvzKScTQz0Lio0eYag==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/core": "3.525.0",
+                "@aws-sdk/core": "3.529.1",
                 "@aws-sdk/middleware-host-header": "3.523.0",
                 "@aws-sdk/middleware-logger": "3.523.0",
                 "@aws-sdk/middleware-recursion-detection": "3.523.0",
@@ -239,14 +255,14 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.525.0.tgz",
-            "integrity": "sha512-zz13k/6RkjPSLmReSeGxd8wzGiiZa4Odr2Tv3wTcxClM4wOjD+zOgGv4Fe32b9AMqaueiCdjbvdu7AKcYxFA4A==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.529.1.tgz",
+            "integrity": "sha512-bimxCWAvRnVcluWEQeadXvHyzWlBWsuGVligsaVZaGF0TLSn0eLpzpN9B1EhHzTf7m0Kh/wGtPSH1JxO6PpB+A==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.525.0",
-                "@aws-sdk/core": "3.525.0",
+                "@aws-sdk/client-sts": "3.529.1",
+                "@aws-sdk/core": "3.529.1",
                 "@aws-sdk/middleware-host-header": "3.523.0",
                 "@aws-sdk/middleware-logger": "3.523.0",
                 "@aws-sdk/middleware-recursion-detection": "3.523.0",
@@ -287,27 +303,17 @@
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/credential-provider-node": "^3.525.0"
+                "@aws-sdk/credential-provider-node": "^3.529.1"
             }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.525.0.tgz",
-            "integrity": "sha512-a8NUGRvO6rkfTZCbMaCsjDjLbERCwIUU9dIywFYcRgbFhkupJ7fSaZz3Het98U51M9ZbTEpaTa3fz0HaJv8VJw==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.529.1.tgz",
+            "integrity": "sha512-Rvk2Sr3MACQTOtngUU+omlf4E17k47dRVXR7OFRD6Ow5iGgC9tkN2q/ExDPW/ktPOmM0lSgzWyQ6/PC/Zq3HUg==",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/core": "3.525.0",
+                "@aws-sdk/core": "3.529.1",
                 "@aws-sdk/middleware-host-header": "3.523.0",
                 "@aws-sdk/middleware-logger": "3.523.0",
                 "@aws-sdk/middleware-recursion-detection": "3.523.0",
@@ -342,41 +348,31 @@
                 "@smithy/util-middleware": "^2.1.3",
                 "@smithy/util-retry": "^2.1.3",
                 "@smithy/util-utf8": "^2.1.1",
-                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/credential-provider-node": "^3.525.0"
+                "@aws-sdk/credential-provider-node": "^3.529.1"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/core": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.525.0.tgz",
-            "integrity": "sha512-E3LtEtMWCriQOFZpVKpLYzbdw/v2PAOEAMhn2VRRZ1g0/g1TXzQrfhEU2yd8l/vQEJaCJ82ooGGg7YECviBUxA==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.529.1.tgz",
+            "integrity": "sha512-Sj42sYPfaL9PHvvciMICxhyrDZjqnnvFbPKDmQL5aFKyXy122qx7RdVqUOQERDmMQfvJh6+0W1zQlLnre89q4Q==",
             "dependencies": {
                 "@smithy/core": "^1.3.5",
                 "@smithy/protocol-http": "^3.2.1",
                 "@smithy/signature-v4": "^2.1.3",
                 "@smithy/smithy-client": "^2.4.2",
                 "@smithy/types": "^2.10.1",
+                "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/core/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.523.0",
@@ -391,11 +387,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/credential-provider-http": {
             "version": "3.525.0",
@@ -416,21 +407,16 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.525.0.tgz",
-            "integrity": "sha512-JDnccfK5JRb9jcgpc9lirL9PyCwGIqY0nKdw3LlX5WL5vTpTG4E1q7rLAlpNh7/tFD1n66Itarfv2tsyHMIqCw==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.529.1.tgz",
+            "integrity": "sha512-RjHsuTvHIwXG7a/3ERexemiD3c9riKMCZQzY2/b0Gg0ButEVbBcMfERtUzWmQ0V4ufe/PEZjP68MH1gupcoF9A==",
             "dependencies": {
-                "@aws-sdk/client-sts": "3.525.0",
+                "@aws-sdk/client-sts": "3.529.1",
                 "@aws-sdk/credential-provider-env": "3.523.0",
                 "@aws-sdk/credential-provider-process": "3.523.0",
-                "@aws-sdk/credential-provider-sso": "3.525.0",
-                "@aws-sdk/credential-provider-web-identity": "3.525.0",
+                "@aws-sdk/credential-provider-sso": "3.529.1",
+                "@aws-sdk/credential-provider-web-identity": "3.529.1",
                 "@aws-sdk/types": "3.523.0",
                 "@smithy/credential-provider-imds": "^2.2.3",
                 "@smithy/property-provider": "^2.1.3",
@@ -442,22 +428,17 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.525.0.tgz",
-            "integrity": "sha512-RJXlO8goGXpnoHQAyrCcJ0QtWEOFa34LSbfdqBIjQX/fwnjUuEmiGdXTV3AZmwYQ7juk49tfBneHbtOP3AGqsQ==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.529.1.tgz",
+            "integrity": "sha512-mvY7F3dMmk/0dZOCfl5sUI1bG0osureBjxhELGCF0KkJqhWI0hIzh8UnPkYytSg3vdc97CMv7pTcozxrdA3b0g==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.523.0",
                 "@aws-sdk/credential-provider-http": "3.525.0",
-                "@aws-sdk/credential-provider-ini": "3.525.0",
+                "@aws-sdk/credential-provider-ini": "3.529.1",
                 "@aws-sdk/credential-provider-process": "3.523.0",
-                "@aws-sdk/credential-provider-sso": "3.525.0",
-                "@aws-sdk/credential-provider-web-identity": "3.525.0",
+                "@aws-sdk/credential-provider-sso": "3.529.1",
+                "@aws-sdk/credential-provider-web-identity": "3.529.1",
                 "@aws-sdk/types": "3.523.0",
                 "@smithy/credential-provider-imds": "^2.2.3",
                 "@smithy/property-provider": "^2.1.3",
@@ -468,11 +449,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.523.0",
@@ -489,18 +465,13 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.525.0.tgz",
-            "integrity": "sha512-7V7ybtufxdD3plxeIeB6aqHZeFIUlAyPphXIUgXrGY10iNcosL970rQPBeggsohe4gCM6UvY2TfMeEcr+ZE8FA==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.529.1.tgz",
+            "integrity": "sha512-KFMKkaoTGDgSJG+o9Ii7AglWG5JQeF6IFw9cXLMwDdIrp3KUmRcUIqe0cjOoCqeQEDGy0VHsimHmKKJ3894i/A==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.525.0",
-                "@aws-sdk/token-providers": "3.525.0",
+                "@aws-sdk/client-sso": "3.529.1",
+                "@aws-sdk/token-providers": "3.529.1",
                 "@aws-sdk/types": "3.523.0",
                 "@smithy/property-provider": "^2.1.3",
                 "@smithy/shared-ini-file-loader": "^2.3.3",
@@ -511,17 +482,12 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.525.0.tgz",
-            "integrity": "sha512-sAukOjR1oKb2JXG4nPpuBFpSwGUhrrY17PG/xbTy8NAoLLhrqRwnErcLfdTfmj6tH+3094k6ws/Sh8a35ae7fA==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.529.1.tgz",
+            "integrity": "sha512-AGuZDOKN+AttjwTjrF47WLqzeEut2YynyxjkXZhxZF/xn8i5Y51kUAUdXsXw1bgR25pAeXQIdhsrQlRa1Pm5kw==",
             "dependencies": {
-                "@aws-sdk/client-sts": "3.525.0",
+                "@aws-sdk/client-sts": "3.529.1",
                 "@aws-sdk/types": "3.523.0",
                 "@smithy/property-provider": "^2.1.3",
                 "@smithy/types": "^2.10.1",
@@ -530,11 +496,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.523.0",
@@ -550,11 +511,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/middleware-logger": {
             "version": "3.523.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.523.0.tgz",
@@ -567,11 +523,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.523.0",
@@ -586,11 +537,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/middleware-sdk-sqs": {
             "version": "3.525.0",
@@ -608,11 +554,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.525.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.525.0.tgz",
@@ -627,11 +568,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.525.0",
@@ -649,17 +585,12 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.525.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.525.0.tgz",
-            "integrity": "sha512-puVjbxuK0Dq7PTQ2HdddHy2eQjOH8GZbump74yWJa6JVpRW84LlOcNmP+79x4Kscvz2ldWB8XDFw/pcCiSDe5A==",
+            "version": "3.529.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.529.1.tgz",
+            "integrity": "sha512-NpgMjsfpqiugbxrYGXtta914N43Mx/H0niidqv8wKMTgWQEtsJvYtOni+kuLXB+LmpjaMFNlpadooFU/bK4buA==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.525.0",
+                "@aws-sdk/client-sso-oidc": "3.529.1",
                 "@aws-sdk/types": "3.523.0",
                 "@smithy/property-provider": "^2.1.3",
                 "@smithy/shared-ini-file-loader": "^2.3.3",
@@ -669,11 +600,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/types": {
             "version": "3.523.0",
@@ -686,11 +612,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-sdk/types/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/util-endpoints": {
             "version": "3.525.0",
@@ -706,11 +627,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/util-locate-window": {
             "version": "3.495.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
@@ -722,11 +638,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.523.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.523.0.tgz",
@@ -737,11 +648,6 @@
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             }
-        },
-        "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.525.0",
@@ -765,11 +671,6 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@aws-sdk/util-utf8-browser": {
             "version": "3.259.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
@@ -778,15 +679,6 @@
                 "tslib": "^2.3.1"
             }
         },
-        "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-=======
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@babel/code-frame": {
             "version": "7.23.5",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
@@ -872,35 +764,35 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
-            "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+            "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.22.8",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.8.tgz",
-            "integrity": "sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.0.tgz",
+            "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.5",
-                "@babel/generator": "^7.22.7",
-                "@babel/helper-compilation-targets": "^7.22.6",
-                "@babel/helper-module-transforms": "^7.22.5",
-                "@babel/helpers": "^7.22.6",
-                "@babel/parser": "^7.22.7",
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.8",
-                "@babel/types": "^7.22.5",
-                "@nicolo-ribaudo/semver-v6": "^6.3.3",
-                "convert-source-map": "^1.7.0",
+                "@babel/code-frame": "^7.23.5",
+                "@babel/generator": "^7.23.6",
+                "@babel/helper-compilation-targets": "^7.23.6",
+                "@babel/helper-module-transforms": "^7.23.3",
+                "@babel/helpers": "^7.24.0",
+                "@babel/parser": "^7.24.0",
+                "@babel/template": "^7.24.0",
+                "@babel/traverse": "^7.24.0",
+                "@babel/types": "^7.24.0",
+                "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.2"
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -910,11 +802,14 @@
                 "url": "https://opencollective.com/babel"
             }
         },
-        "node_modules/@babel/core/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "dev": true
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
         },
         "node_modules/@babel/generator": {
             "version": "7.23.6",
@@ -932,22 +827,28 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
-            "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+            "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.22.6",
-                "@babel/helper-validator-option": "^7.22.5",
-                "@nicolo-ribaudo/semver-v6": "^6.3.3",
-                "browserslist": "^4.21.9",
-                "lru-cache": "^5.1.1"
+                "@babel/compat-data": "^7.23.5",
+                "@babel/helper-validator-option": "^7.23.5",
+                "browserslist": "^4.22.2",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
@@ -985,40 +886,40 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-            "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.22.15"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
-            "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
+            "version": "7.23.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+            "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-module-imports": "^7.22.15",
                 "@babel/helper-simple-access": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-validator-identifier": "^7.22.20"
             },
             "engines": {
                 "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-            "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+            "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -1067,23 +968,23 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-            "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+            "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
-            "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.0.tgz",
+            "integrity": "sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.6",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.24.0",
+                "@babel/traverse": "^7.24.0",
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1101,7 +1002,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-<<<<<<< HEAD
             }
         },
         "node_modules/@babel/highlight/node_modules/ansi-styles": {
@@ -1199,105 +1099,6 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-=======
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
-        },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/parser": {
-            "version": "7.22.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-            "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
-            "dev": true,
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-async-generators": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@babel/plugin-syntax-bigint": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
@@ -1347,9 +1148,9 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-            "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+            "version": "7.23.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+            "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1449,9 +1250,9 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-            "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+            "version": "7.23.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+            "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5"
@@ -1528,9 +1329,9 @@
             "dev": true
         },
         "node_modules/@colors/colors": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+            "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
             "dev": true,
             "engines": {
                 "node": ">=0.1.90"
@@ -1937,18 +1738,18 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-            "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+            "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-            "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -1969,22 +1770,22 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.44.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-            "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
@@ -2005,9 +1806,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+            "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -2031,7 +1832,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
-<<<<<<< HEAD
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -2101,77 +1901,6 @@
                 "node": ">=8"
             }
         },
-=======
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -2180,6 +1909,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true
         },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
@@ -2191,16 +1926,16 @@
             }
         },
         "node_modules/@jest/console": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
-            "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+            "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
-                "jest-message-util": "^29.6.1",
-                "jest-util": "^29.6.1",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -2208,37 +1943,37 @@
             }
         },
         "node_modules/@jest/core": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
-            "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+            "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
             "dev": true,
             "dependencies": {
-                "@jest/console": "^29.6.1",
-                "@jest/reporters": "^29.6.1",
-                "@jest/test-result": "^29.6.1",
-                "@jest/transform": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/console": "^29.7.0",
+                "@jest/reporters": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
                 "ci-info": "^3.2.0",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.9",
-                "jest-changed-files": "^29.5.0",
-                "jest-config": "^29.6.1",
-                "jest-haste-map": "^29.6.1",
-                "jest-message-util": "^29.6.1",
-                "jest-regex-util": "^29.4.3",
-                "jest-resolve": "^29.6.1",
-                "jest-resolve-dependencies": "^29.6.1",
-                "jest-runner": "^29.6.1",
-                "jest-runtime": "^29.6.1",
-                "jest-snapshot": "^29.6.1",
-                "jest-util": "^29.6.1",
-                "jest-validate": "^29.6.1",
-                "jest-watcher": "^29.6.1",
+                "jest-changed-files": "^29.7.0",
+                "jest-config": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-resolve-dependencies": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "jest-watcher": "^29.7.0",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^29.6.1",
+                "pretty-format": "^29.7.0",
                 "slash": "^3.0.0",
                 "strip-ansi": "^6.0.0"
             },
@@ -2255,89 +1990,88 @@
             }
         },
         "node_modules/@jest/environment": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
-            "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+            "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
             "dev": true,
             "dependencies": {
-                "@jest/fake-timers": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
-                "jest-mock": "^29.6.1"
+                "jest-mock": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/expect": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
-            "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+            "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
             "dev": true,
             "dependencies": {
-                "expect": "^29.6.1",
-                "jest-snapshot": "^29.6.1"
+                "expect": "^29.7.0",
+                "jest-snapshot": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/expect-utils": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
-            "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+            "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
             "dev": true,
             "dependencies": {
-                "jest-get-type": "^29.4.3"
+                "jest-get-type": "^29.6.3"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/fake-timers": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
-            "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+            "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/node": "*",
-                "jest-message-util": "^29.6.1",
-                "jest-mock": "^29.6.1",
-                "jest-util": "^29.6.1"
+                "jest-message-util": "^29.7.0",
+                "jest-mock": "^29.7.0",
+                "jest-util": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-<<<<<<< HEAD
             }
         },
         "node_modules/@jest/globals": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
-            "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+            "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.6.1",
-                "@jest/expect": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "jest-mock": "^29.6.1"
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "jest-mock": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/reporters": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
-            "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+            "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
             "dev": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.6.1",
-                "@jest/test-result": "^29.6.1",
-                "@jest/transform": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/console": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@jridgewell/trace-mapping": "^0.3.18",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
@@ -2346,13 +2080,13 @@
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.9",
                 "istanbul-lib-coverage": "^3.0.0",
-                "istanbul-lib-instrument": "^5.1.0",
+                "istanbul-lib-instrument": "^6.0.0",
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
                 "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.6.1",
-                "jest-util": "^29.6.1",
-                "jest-worker": "^29.6.1",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-worker": "^29.7.0",
                 "slash": "^3.0.0",
                 "string-length": "^4.0.1",
                 "strip-ansi": "^6.0.0",
@@ -2371,9 +2105,9 @@
             }
         },
         "node_modules/@jest/schemas": {
-            "version": "29.6.0",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-            "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "dev": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
@@ -2383,9 +2117,9 @@
             }
         },
         "node_modules/@jest/source-map": {
-            "version": "29.6.0",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.0.tgz",
-            "integrity": "sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+            "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.18",
@@ -2397,13 +2131,13 @@
             }
         },
         "node_modules/@jest/test-result": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
-            "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+            "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
             "dev": true,
             "dependencies": {
-                "@jest/console": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/console": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "collect-v8-coverage": "^1.0.0"
             },
@@ -2412,14 +2146,14 @@
             }
         },
         "node_modules/@jest/test-sequencer": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
-            "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+            "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
             "dev": true,
             "dependencies": {
-                "@jest/test-result": "^29.6.1",
+                "@jest/test-result": "^29.7.0",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.6.1",
+                "jest-haste-map": "^29.7.0",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -2427,22 +2161,22 @@
             }
         },
         "node_modules/@jest/transform": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
-            "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+            "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "@jridgewell/trace-mapping": "^0.3.18",
                 "babel-plugin-istanbul": "^6.1.1",
                 "chalk": "^4.0.0",
                 "convert-source-map": "^2.0.0",
                 "fast-json-stable-stringify": "^2.1.0",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.6.1",
-                "jest-regex-util": "^29.4.3",
-                "jest-util": "^29.6.1",
+                "jest-haste-map": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-util": "^29.7.0",
                 "micromatch": "^4.0.4",
                 "pirates": "^4.0.4",
                 "slash": "^3.0.0",
@@ -2453,12 +2187,12 @@
             }
         },
         "node_modules/@jest/types": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-            "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "dev": true,
             "dependencies": {
-                "@jest/schemas": "^29.6.0",
+                "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
                 "@types/node": "*",
@@ -2470,32 +2204,32 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -2508,28 +2242,22 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.18",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-            "dev": true
-        },
-        "node_modules/@nicolo-ribaudo/semver-v6": {
-            "version": "6.3.3",
-            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
-            "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
+        "node_modules/@mongodb-js/saslprep": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
+            "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
+            "optional": true,
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -2574,9 +2302,9 @@
             "dev": true
         },
         "node_modules/@sinonjs/commons": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
             "dependencies": {
                 "type-detect": "4.0.8"
@@ -2592,150 +2320,110 @@
             }
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
-            "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.4.tgz",
+            "integrity": "sha512-66HO817oIZ2otLIqy06R5muapqZjkgF1jfU0wyNko8cuqZNu8nbS9ljlhcRYw/M/uWRJzB9ih81DLSHhYbBLlQ==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/abort-controller/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.4.tgz",
-            "integrity": "sha512-AW2WUZmBAzgO3V3ovKtsUbI3aBNMeQKFDumoqkNxaVDWF/xfnxAWqBKDr/NuG7c06N2Rm4xeZLPiJH/d+na0HA==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.5.tgz",
+            "integrity": "sha512-LcBB5JQC3Tx2ZExIJzfvWaajhFIwHrUNQeqxhred2r5nnqrdly9uoCrvM1sxOOdghYuWWm2Kr8tBCDOmxsgeTA==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.2.4",
-                "@smithy/types": "^2.10.1",
+                "@smithy/node-config-provider": "^2.2.5",
+                "@smithy/types": "^2.11.0",
                 "@smithy/util-config-provider": "^2.2.1",
-                "@smithy/util-middleware": "^2.1.3",
+                "@smithy/util-middleware": "^2.1.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/config-resolver/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/core": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.5.tgz",
-            "integrity": "sha512-Rrc+e2Jj6Gu7Xbn0jvrzZlSiP2CZocIOfZ9aNUA82+1sa6GBnxqL9+iZ9EKHeD9aqD1nU8EK4+oN2EiFpSv7Yw==",
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.7.tgz",
+            "integrity": "sha512-zHrrstOO78g+/rOJoHi4j3mGUBtsljRhcKNzloWPv1XIwgcFUi+F1YFKr2qPQ3z7Ls5dNc4L2SPrVarNFIQqog==",
             "dependencies": {
-                "@smithy/middleware-endpoint": "^2.4.4",
-                "@smithy/middleware-retry": "^2.1.4",
-                "@smithy/middleware-serde": "^2.1.3",
-                "@smithy/protocol-http": "^3.2.1",
-                "@smithy/smithy-client": "^2.4.2",
-                "@smithy/types": "^2.10.1",
-                "@smithy/util-middleware": "^2.1.3",
+                "@smithy/middleware-endpoint": "^2.4.6",
+                "@smithy/middleware-retry": "^2.1.6",
+                "@smithy/middleware-serde": "^2.2.1",
+                "@smithy/protocol-http": "^3.2.2",
+                "@smithy/smithy-client": "^2.4.4",
+                "@smithy/types": "^2.11.0",
+                "@smithy/util-middleware": "^2.1.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/core/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.4.tgz",
-            "integrity": "sha512-DdatjmBZQnhGe1FhI8gO98f7NmvQFSDiZTwC3WMvLTCKQUY+Y1SVkhJqIuLu50Eb7pTheoXQmK+hKYUgpUWsNA==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.6.tgz",
+            "integrity": "sha512-+xQe4Pite0kdk9qn0Vyw5BRVh0iSlj+T4TEKRXr4E1wZKtVgIzGlkCrfICSjiPVFkPxk4jMpVboMYdEiiA88/w==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.2.4",
-                "@smithy/property-provider": "^2.1.3",
-                "@smithy/types": "^2.10.1",
-                "@smithy/url-parser": "^2.1.3",
+                "@smithy/node-config-provider": "^2.2.5",
+                "@smithy/property-provider": "^2.1.4",
+                "@smithy/types": "^2.11.0",
+                "@smithy/url-parser": "^2.1.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/eventstream-codec": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
-            "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.4.tgz",
+            "integrity": "sha512-UkiieTztP7adg8EuqZvB0Y4LewdleZCJU7Kgt9RDutMsRYqO32fMpWeQHeTHaIMosmzcRZUykMRrhwGJe9mP3A==",
             "dependencies": {
                 "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "@smithy/util-hex-encoding": "^2.1.1",
                 "tslib": "^2.5.0"
             }
         },
-        "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
-            "integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.4.tgz",
+            "integrity": "sha512-DSUtmsnIx26tPuyyrK49dk2DAhPgEw6xRW7V62nMHIB5dk3NqhGnwcKO2fMdt/l3NUVgia34ZsSJA8bD+3nh7g==",
             "dependencies": {
-                "@smithy/protocol-http": "^3.2.1",
-                "@smithy/querystring-builder": "^2.1.3",
-                "@smithy/types": "^2.10.1",
-                "@smithy/util-base64": "^2.1.1",
+                "@smithy/protocol-http": "^3.2.2",
+                "@smithy/querystring-builder": "^2.1.4",
+                "@smithy/types": "^2.11.0",
+                "@smithy/util-base64": "^2.2.0",
                 "tslib": "^2.5.0"
             }
         },
-        "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/hash-node": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.3.tgz",
-            "integrity": "sha512-FsAPCUj7VNJIdHbSxMd5uiZiF20G2zdSDgrgrDrHqIs/VMxK85Vqk5kMVNNDMCZmMezp6UKnac0B4nAyx7HJ9g==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.4.tgz",
+            "integrity": "sha512-uvCcpDLXaTTL0X/9ezF8T8sS77UglTfZVQaUOBiCvR0QydeSyio3t0Hj3QooVdyFsKTubR8gCk/ubLk3vAyDng==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "@smithy/util-buffer-from": "^2.1.1",
-                "@smithy/util-utf8": "^2.1.1",
+                "@smithy/util-utf8": "^2.2.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/hash-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.3.tgz",
-            "integrity": "sha512-wkra7d/G4CbngV4xsjYyAYOvdAhahQje/WymuQdVEnXFExJopEu7fbL5AEAlBPgWHXwu94VnCSG00gVzRfExyg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.4.tgz",
+            "integrity": "sha512-QzlNBl6jt3nb9jNnE51wTegReVvUdozyMMrFEyb/rc6AzPID1O+qMJYjAAoNw098y0CZVfCpEnoK2+mfBOd8XA==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             }
-        },
-        "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/is-array-buffer": {
             "version": "2.1.1",
@@ -2748,78 +2436,58 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/md5-js": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.3.tgz",
-            "integrity": "sha512-zmn3M6+mP4IJlSmXBN9964AztgkIO8b5lRzAgdJn9AdCFwA6xLkcW2B6uEnpBjvotxtQMmXTUP19tIO7NmFPpw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.4.tgz",
+            "integrity": "sha512-WHTnnYJPKE7Sy49DogLuox42TnlwD3cQ6TObPD6WFWjKocWIdpEpIvdJHwWUfSFf0JIi8ON8z6ZEhsnyKVCcLQ==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
-                "@smithy/util-utf8": "^2.1.1",
+                "@smithy/types": "^2.11.0",
+                "@smithy/util-utf8": "^2.2.0",
                 "tslib": "^2.5.0"
             }
-        },
-        "node_modules/@smithy/md5-js/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.3.tgz",
-            "integrity": "sha512-aJduhkC+dcXxdnv5ZpM3uMmtGmVFKx412R1gbeykS5HXDmRU6oSsyy2SoHENCkfOGKAQOjVE2WVqDJibC0d21g==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.4.tgz",
+            "integrity": "sha512-C6VRwfcr0w9qRFhDGCpWMVhlEIBFlmlPRP1aX9Cv9xDj9SUwlDrNvoV1oP1vjRYuLxCDgovBBynCwwcluS2wLw==",
             "dependencies": {
-                "@smithy/protocol-http": "^3.2.1",
-                "@smithy/types": "^2.10.1",
+                "@smithy/protocol-http": "^3.2.2",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
-            "integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.6.tgz",
+            "integrity": "sha512-AsXtUXHPOAS0EGZUSFOsVJvc7p0KL29PGkLxLfycPOcFVLru/oinYB6yvyL73ZZPX2OB8sMYUMrj7eH2kI7V/w==",
             "dependencies": {
-                "@smithy/middleware-serde": "^2.1.3",
-                "@smithy/node-config-provider": "^2.2.4",
-                "@smithy/shared-ini-file-loader": "^2.3.4",
-                "@smithy/types": "^2.10.1",
-                "@smithy/url-parser": "^2.1.3",
-                "@smithy/util-middleware": "^2.1.3",
+                "@smithy/middleware-serde": "^2.2.1",
+                "@smithy/node-config-provider": "^2.2.5",
+                "@smithy/shared-ini-file-loader": "^2.3.5",
+                "@smithy/types": "^2.11.0",
+                "@smithy/url-parser": "^2.1.4",
+                "@smithy/util-middleware": "^2.1.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/middleware-retry": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.4.tgz",
-            "integrity": "sha512-Cyolv9YckZTPli1EkkaS39UklonxMd08VskiuMhURDjC0HHa/AD6aK/YoD21CHv9s0QLg0WMLvk9YeLTKkXaFQ==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.6.tgz",
+            "integrity": "sha512-khpSV0NxqMHfa06kfG4WYv+978sVvfTFmn0hIFKKwOXtIxyYtPKiQWFT4nnwZD07fGdYGbtCBu3YALc8SsA5mA==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.2.4",
-                "@smithy/protocol-http": "^3.2.1",
-                "@smithy/service-error-classification": "^2.1.3",
-                "@smithy/smithy-client": "^2.4.2",
-                "@smithy/types": "^2.10.1",
-                "@smithy/util-middleware": "^2.1.3",
-                "@smithy/util-retry": "^2.1.3",
+                "@smithy/node-config-provider": "^2.2.5",
+                "@smithy/protocol-http": "^3.2.2",
+                "@smithy/service-error-classification": "^2.1.4",
+                "@smithy/smithy-client": "^2.4.4",
+                "@smithy/types": "^2.11.0",
+                "@smithy/util-middleware": "^2.1.4",
+                "@smithy/util-retry": "^2.1.4",
                 "tslib": "^2.5.0",
                 "uuid": "^8.3.2"
             },
@@ -2827,124 +2495,89 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/middleware-retry/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/middleware-serde": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
-            "integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.2.1.tgz",
+            "integrity": "sha512-VAWRWqnNjgccebndpyK94om4ZTYzXLQxUmNCXYzM/3O9MTfQjTNBgtFtQwyIIez6z7LWcCsXmnKVIOE9mLqAHQ==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/middleware-serde/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
-            "integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.4.tgz",
+            "integrity": "sha512-Qqs2ba8Ax1rGKOSGJS2JN23fhhox2WMdRuzx0NYHtXzhxbJOIMmz9uQY6Hf4PY8FPteBPp1+h0j5Fmr+oW12sg==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/middleware-stack/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
-            "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.5.tgz",
+            "integrity": "sha512-CxPf2CXhjO79IypHJLBATB66Dw6suvr1Yc2ccY39hpR6wdse3pZ3E8RF83SODiNH0Wjmkd0ze4OF8exugEixgA==",
             "dependencies": {
-                "@smithy/property-provider": "^2.1.3",
-                "@smithy/shared-ini-file-loader": "^2.3.4",
-                "@smithy/types": "^2.10.1",
+                "@smithy/property-provider": "^2.1.4",
+                "@smithy/shared-ini-file-loader": "^2.3.5",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/node-config-provider/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
-            "integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.2.tgz",
+            "integrity": "sha512-yrj3c1g145uiK5io+1UPbJAHo8BSGORkBzrmzvAsOmBKb+1p3jmM8ZwNLDH/HTTxVLm9iM5rMszx+iAh1HUC4Q==",
             "dependencies": {
-                "@smithy/abort-controller": "^2.1.3",
-                "@smithy/protocol-http": "^3.2.1",
-                "@smithy/querystring-builder": "^2.1.3",
-                "@smithy/types": "^2.10.1",
+                "@smithy/abort-controller": "^2.1.4",
+                "@smithy/protocol-http": "^3.2.2",
+                "@smithy/querystring-builder": "^2.1.4",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/node-http-handler/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/property-provider": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
-            "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.4.tgz",
+            "integrity": "sha512-nWaY/MImj1BiXZ9WY65h45dcxOx8pl06KYoHxwojDxDL+Q9yLU1YnZpgv8zsHhEftlj9KhePENjQTlNowWVyug==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/property-provider/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-            "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.2.tgz",
+            "integrity": "sha512-xYBlllOQcOuLoxzhF2u8kRHhIFGQpDeTQj/dBSnw4kfI29WMKL5RnW1m9YjnJAJ49miuIvrkJR+gW5bCQ+Mchw==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/protocol-http/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/querystring-builder": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
-            "integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.4.tgz",
+            "integrity": "sha512-LXSL0J/nRWvGT+jIj+Fip3j0J1ZmHkUyBFRzg/4SmPNCLeDrtVu7ptKOnTboPsFZu5BxmpYok3kJuQzzRdrhbw==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "@smithy/util-uri-escape": "^2.1.1",
                 "tslib": "^2.5.0"
             },
@@ -2952,147 +2585,108 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/querystring-builder/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/querystring-parser": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
-            "integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.4.tgz",
+            "integrity": "sha512-U2b8olKXgZAs0eRo7Op11jTNmmcC/sqYmsA7vN6A+jkGnDvJlEl7AetUegbBzU8q3D6WzC5rhR/joIy8tXPzIg==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/querystring-parser/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/service-error-classification": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.3.tgz",
-            "integrity": "sha512-iUrpSsem97bbXHHT/v3s7vaq8IIeMo6P6cXdeYHrx0wOJpMeBGQF7CB0mbJSiTm3//iq3L55JiEm8rA7CTVI8A==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.4.tgz",
+            "integrity": "sha512-JW2Hthy21evnvDmYYk1kItOmbp3X5XI5iqorXgFEunb6hQfSDZ7O1g0Clyxg7k/Pcr9pfLk5xDIR2To/IohlsQ==",
             "dependencies": {
-                "@smithy/types": "^2.10.1"
+                "@smithy/types": "^2.11.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
-            "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.5.tgz",
+            "integrity": "sha512-oI99+hOvsM8oAJtxAGmoL/YCcGXtbP0fjPseYGaNmJ4X5xOFTer0KPk7AIH3AL6c5AlYErivEi1X/X78HgTVIw==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
-            "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.4.tgz",
+            "integrity": "sha512-gnu9gCn0qQ8IdhNjs6o3QVCXzUs33znSDYwVMWo3nX4dM6j7z9u6FC302ShYyVWfO4MkVMuGCCJ6nl3PcH7V1Q==",
             "dependencies": {
-                "@smithy/eventstream-codec": "^2.1.3",
+                "@smithy/eventstream-codec": "^2.1.4",
                 "@smithy/is-array-buffer": "^2.1.1",
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "@smithy/util-hex-encoding": "^2.1.1",
-                "@smithy/util-middleware": "^2.1.3",
+                "@smithy/util-middleware": "^2.1.4",
                 "@smithy/util-uri-escape": "^2.1.1",
-                "@smithy/util-utf8": "^2.1.1",
+                "@smithy/util-utf8": "^2.2.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
-            "integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.4.tgz",
+            "integrity": "sha512-SNE17wjycPZIJ2P5sv6wMTteV/vQVPdaqQkoK1KeGoWHXx79t3iLhQXj1uqRdlkMUS9pXJrLOAS+VvUSOYwQKw==",
             "dependencies": {
-                "@smithy/middleware-endpoint": "^2.4.4",
-                "@smithy/middleware-stack": "^2.1.3",
-                "@smithy/protocol-http": "^3.2.1",
-                "@smithy/types": "^2.10.1",
-                "@smithy/util-stream": "^2.1.3",
+                "@smithy/middleware-endpoint": "^2.4.6",
+                "@smithy/middleware-stack": "^2.1.4",
+                "@smithy/protocol-http": "^3.2.2",
+                "@smithy/types": "^2.11.0",
+                "@smithy/util-stream": "^2.1.4",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/smithy-client/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/types": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-            "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.11.0.tgz",
+            "integrity": "sha512-AR0SXO7FuAskfNhyGfSTThpLRntDI5bOrU0xrpVYU0rZyjl3LBXInZFMTP/NNSd7IS6Ksdtar0QvnrPRIhVrLQ==",
             "dependencies": {
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/types/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/url-parser": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
-            "integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.4.tgz",
+            "integrity": "sha512-1hTy6UYRYqOZlHKH2/2NzdNQ4NNmW2Lp0sYYvztKy+dEQuLvZL9w88zCzFQqqFer3DMcscYOshImxkJTGdV+rg==",
             "dependencies": {
-                "@smithy/querystring-parser": "^2.1.3",
-                "@smithy/types": "^2.10.1",
+                "@smithy/querystring-parser": "^2.1.4",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             }
         },
-        "node_modules/@smithy/url-parser/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-base64": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
-            "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.2.0.tgz",
+            "integrity": "sha512-RiQI/Txu0SxCR38Ky5BMEVaFfkNTBjpbxlr2UhhxggSmnsHDQPZJWMtPoXs7TWZaseslIlAWMiHmqRT3AV/P2w==",
             "dependencies": {
                 "@smithy/util-buffer-from": "^2.1.1",
+                "@smithy/util-utf8": "^2.2.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/util-base64/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/util-body-length-browser": {
             "version": "2.1.1",
@@ -3101,11 +2695,6 @@
             "dependencies": {
                 "tslib": "^2.5.0"
             }
-        },
-        "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/util-body-length-node": {
             "version": "2.2.1",
@@ -3117,11 +2706,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/util-buffer-from": {
             "version": "2.1.1",
@@ -3135,11 +2719,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-config-provider": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
@@ -3151,19 +2730,14 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-config-provider/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.4.tgz",
-            "integrity": "sha512-J6XAVY+/g7jf03QMnvqPyU+8jqGrrtXoKWFVOS+n1sz0Lg8HjHJ1ANqaDN+KTTKZRZlvG8nU5ZrJOUL6VdwgcQ==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.6.tgz",
+            "integrity": "sha512-lM2JMYCilrejfGf8WWnVfrKly3vf+mc5x9TrTpT++qIKP452uWfLqlaUxbz1TkSfhqm8RjrlY22589B9aI8A9w==",
             "dependencies": {
-                "@smithy/property-provider": "^2.1.3",
-                "@smithy/smithy-client": "^2.4.2",
-                "@smithy/types": "^2.10.1",
+                "@smithy/property-provider": "^2.1.4",
+                "@smithy/smithy-client": "^2.4.4",
+                "@smithy/types": "^2.11.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.5.0"
             },
@@ -3171,50 +2745,35 @@
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.3.tgz",
-            "integrity": "sha512-ttUISrv1uVOjTlDa3nznX33f0pthoUlP+4grhTvOzcLhzArx8qHB94/untGACOG3nlf8vU20nI2iWImfzoLkYA==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.6.tgz",
+            "integrity": "sha512-UmUbPHbkBJCXRFbq+FPLpVwiFPHj1oPWXJS2f2sy23PtXM94c9X5EceI6JKuKdBty+tzhrAs5JbmPM/HvmDB8Q==",
             "dependencies": {
-                "@smithy/config-resolver": "^2.1.4",
-                "@smithy/credential-provider-imds": "^2.2.4",
-                "@smithy/node-config-provider": "^2.2.4",
-                "@smithy/property-provider": "^2.1.3",
-                "@smithy/smithy-client": "^2.4.2",
-                "@smithy/types": "^2.10.1",
+                "@smithy/config-resolver": "^2.1.5",
+                "@smithy/credential-provider-imds": "^2.2.6",
+                "@smithy/node-config-provider": "^2.2.5",
+                "@smithy/property-provider": "^2.1.4",
+                "@smithy/smithy-client": "^2.4.4",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-endpoints": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.4.tgz",
-            "integrity": "sha512-/qAeHmK5l4yQ4/bCIJ9p49wDe9rwWtOzhPHblu386fwPNT3pxmodgcs9jDCV52yK9b4rB8o9Sj31P/7Vzka1cg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.5.tgz",
+            "integrity": "sha512-tgDpaUNsUtRvNiBulKU1VnpoXU1GINMfZZXunRhUXOTBEAufG1Wp79uDXLau2gg1RZ4dpAR6lXCkrmddihCGUg==",
             "dependencies": {
-                "@smithy/node-config-provider": "^2.2.4",
-                "@smithy/types": "^2.10.1",
+                "@smithy/node-config-provider": "^2.2.5",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
-        },
-        "node_modules/@smithy/util-endpoints/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/util-hex-encoding": {
             "version": "2.1.1",
@@ -3227,68 +2786,48 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-middleware": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
-            "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.4.tgz",
+            "integrity": "sha512-5yYNOgCN0DL0OplME0pthoUR/sCfipnROkbTO7m872o0GHCVNJj5xOFJ143rvHNA54+pIPMLum4z2DhPC2pVGA==",
             "dependencies": {
-                "@smithy/types": "^2.10.1",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-middleware/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-retry": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.3.tgz",
-            "integrity": "sha512-Kbvd+GEMuozbNUU3B89mb99tbufwREcyx2BOX0X2+qHjq6Gvsah8xSDDgxISDwcOHoDqUWO425F0Uc/QIRhYkg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.4.tgz",
+            "integrity": "sha512-JRZwhA3fhkdenSEYIWatC8oLwt4Bdf2LhHbNQApqb7yFoIGMl4twcYI3BcJZ7YIBZrACA9jGveW6tuCd836XzQ==",
             "dependencies": {
-                "@smithy/service-error-classification": "^2.1.3",
-                "@smithy/types": "^2.10.1",
+                "@smithy/service-error-classification": "^2.1.4",
+                "@smithy/types": "^2.11.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/@smithy/util-retry/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-stream": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
-            "integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.4.tgz",
+            "integrity": "sha512-CiWaFPXstoR7v/PGHddFckovkhJb28wgQR7LwIt6RsQCJeRIHvUTVWhXw/Pco6Jm6nz/vfzN9FFdj/JN7RTkxQ==",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^2.4.3",
-                "@smithy/node-http-handler": "^2.4.1",
-                "@smithy/types": "^2.10.1",
-                "@smithy/util-base64": "^2.1.1",
+                "@smithy/fetch-http-handler": "^2.4.4",
+                "@smithy/node-http-handler": "^2.4.2",
+                "@smithy/types": "^2.11.0",
+                "@smithy/util-base64": "^2.2.0",
                 "@smithy/util-buffer-from": "^2.1.1",
                 "@smithy/util-hex-encoding": "^2.1.1",
-                "@smithy/util-utf8": "^2.1.1",
+                "@smithy/util-utf8": "^2.2.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@smithy/util-stream/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/@smithy/util-uri-escape": {
             "version": "2.1.1",
@@ -3301,15 +2840,10 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
         "node_modules/@smithy/util-utf8": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
-            "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.2.0.tgz",
+            "integrity": "sha512-hBsKr5BqrDrKS8qy+YcV7/htmMGxriA1PREOf/8AGBhHIZnfilVv1Waf1OyKhSbFW15U/8+gcMUQ9/Kk5qwpHQ==",
             "dependencies": {
                 "@smithy/util-buffer-from": "^2.1.1",
                 "tslib": "^2.5.0"
@@ -3318,303 +2852,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-utf8/node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        },
-=======
-            }
-        },
-        "node_modules/@jest/globals": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
-            "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
-            "dev": true,
-            "dependencies": {
-                "@jest/environment": "^29.6.1",
-                "@jest/expect": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "jest-mock": "^29.6.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/reporters": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
-            "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
-            "dev": true,
-            "dependencies": {
-                "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.6.1",
-                "@jest/test-result": "^29.6.1",
-                "@jest/transform": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "istanbul-lib-coverage": "^3.0.0",
-                "istanbul-lib-instrument": "^5.1.0",
-                "istanbul-lib-report": "^3.0.0",
-                "istanbul-lib-source-maps": "^4.0.0",
-                "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.6.1",
-                "jest-util": "^29.6.1",
-                "jest-worker": "^29.6.1",
-                "slash": "^3.0.0",
-                "string-length": "^4.0.1",
-                "strip-ansi": "^6.0.0",
-                "v8-to-istanbul": "^9.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@jest/schemas": {
-            "version": "29.6.0",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-            "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
-            "dev": true,
-            "dependencies": {
-                "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/source-map": {
-            "version": "29.6.0",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.0.tgz",
-            "integrity": "sha512-oA+I2SHHQGxDCZpbrsCQSoMLb3Bz547JnM+jUr9qEbuw0vQlWZfpPS7CO9J7XiwKicEz9OFn/IYoLkkiUD7bzA==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.2.9"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-result": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
-            "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/console": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "collect-v8-coverage": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-sequencer": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
-            "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
-            "dev": true,
-            "dependencies": {
-                "@jest/test-result": "^29.6.1",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.6.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/transform": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
-            "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/types": "^29.6.1",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "babel-plugin-istanbul": "^6.1.1",
-                "chalk": "^4.0.0",
-                "convert-source-map": "^2.0.0",
-                "fast-json-stable-stringify": "^2.1.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.6.1",
-                "jest-regex-util": "^29.4.3",
-                "jest-util": "^29.6.1",
-                "micromatch": "^4.0.4",
-                "pirates": "^4.0.4",
-                "slash": "^3.0.0",
-                "write-file-atomic": "^4.0.2"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/types": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-            "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.0",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-            "dev": true,
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-            "dev": true,
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
-        },
-        "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.18",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
-            }
-        },
-        "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-            "dev": true
-        },
-        "node_modules/@mongodb-js/saslprep": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
-            "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
-            "optional": true,
-            "dependencies": {
-                "sparse-bitfield": "^3.0.3"
-            }
-        },
-        "node_modules/@nicolo-ribaudo/semver-v6": {
-            "version": "6.3.3",
-            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
-            "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-            "dev": true
-        },
-        "node_modules/@sinonjs/commons": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-            "dev": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-            "dev": true,
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -3640,9 +2877,9 @@
             "dev": true
         },
         "node_modules/@types/babel__core": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
-            "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
             "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.20.7",
@@ -3653,18 +2890,18 @@
             }
         },
         "node_modules/@types/babel__generator": {
-            "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
-            "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+            "version": "7.6.8",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+            "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
         },
         "node_modules/@types/babel__template": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-            "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
             "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
@@ -3672,18 +2909,18 @@
             }
         },
         "node_modules/@types/babel__traverse": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
-            "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+            "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
         },
         "node_modules/@types/body-parser": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-            "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+            "version": "1.19.5",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+            "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
             "dev": true,
             "dependencies": {
                 "@types/connect": "*",
@@ -3691,18 +2928,18 @@
             }
         },
         "node_modules/@types/connect": {
-            "version": "3.4.35",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-            "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+            "version": "3.4.38",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/express": {
-            "version": "4.17.17",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-            "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
@@ -3712,9 +2949,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.35",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
-            "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
+            "version": "4.17.43",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
+            "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -3724,48 +2961,48 @@
             }
         },
         "node_modules/@types/graceful-fs": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
-            "integrity": "sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/http-errors": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-            "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+            "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
             "dev": true
         },
         "node_modules/@types/istanbul-lib-coverage": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-            "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
             "dev": true
         },
         "node_modules/@types/istanbul-lib-report": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-            "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
             "dev": true,
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
         },
         "node_modules/@types/istanbul-reports": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-            "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
             "dev": true,
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.5.2",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
-            "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
+            "version": "29.5.12",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+            "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -3773,50 +3010,47 @@
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.12",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-            "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
         "node_modules/@types/mime": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-            "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.4.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
-            "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g=="
-        },
-        "node_modules/@types/prettier": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-            "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-            "dev": true
+            "version": "20.11.25",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+            "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/qs": {
-            "version": "6.9.7",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+            "version": "6.9.12",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
+            "integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-            "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "node_modules/@types/send": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
-            "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
             "dev": true,
             "dependencies": {
                 "@types/mime": "^1",
@@ -3824,9 +3058,9 @@
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
-            "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+            "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
             "dev": true,
             "dependencies": {
                 "@types/http-errors": "*",
@@ -3835,9 +3069,9 @@
             }
         },
         "node_modules/@types/stack-utils": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-            "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true
         },
         "node_modules/@types/strip-bom": {
@@ -3853,9 +3087,9 @@
             "dev": true
         },
         "node_modules/@types/swagger-ui-express": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
-            "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+            "integrity": "sha512-UVSiGYXa5IzdJJG3hrc86e8KdZWLYxyEsVoUI4iPXc7CO4VZ3AfNP8d/8+hrDRIqz+HAaSMtZSqAsF3Nq2X/Dg==",
             "dev": true,
             "dependencies": {
                 "@types/express": "*",
@@ -3863,9 +3097,9 @@
             }
         },
         "node_modules/@types/triple-beam": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
-            "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+            "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
             "dev": true
         },
         "node_modules/@types/webidl-conversions": {
@@ -3883,30 +3117,30 @@
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.24",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
-            "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+            "version": "17.0.32",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+            "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
         },
         "node_modules/@types/yargs-parser": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-            "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.61.0.tgz",
-            "integrity": "sha512-A5l/eUAug103qtkwccSCxn8ZRwT+7RXWkFECdA4Cvl1dOlDUgTpAOfSEElZn2uSUxhdDpnCdetrf0jvU4qrL+g==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+            "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
-                "@typescript-eslint/scope-manager": "5.61.0",
-                "@typescript-eslint/type-utils": "5.61.0",
-                "@typescript-eslint/utils": "5.61.0",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/type-utils": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
@@ -3932,14 +3166,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.61.0.tgz",
-            "integrity": "sha512-yGr4Sgyh8uO6fSi9hw3jAFXNBHbCtKKFMdX2IkT3ZqpKmtAq3lHS4ixB/COFuAIJpwl9/AqF7j72ZDWYKmIfvg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+            "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.61.0",
-                "@typescript-eslint/types": "5.61.0",
-                "@typescript-eslint/typescript-estree": "5.61.0",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3959,13 +3193,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.61.0.tgz",
-            "integrity": "sha512-W8VoMjoSg7f7nqAROEmTt6LoBpn81AegP7uKhhW5KzYlehs8VV0ZW0fIDVbcZRcaP3aPSW+JZFua+ysQN+m/Nw==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.61.0",
-                "@typescript-eslint/visitor-keys": "5.61.0"
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3976,13 +3210,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.61.0.tgz",
-            "integrity": "sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+            "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.61.0",
-                "@typescript-eslint/utils": "5.61.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -4003,9 +3237,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.61.0.tgz",
-            "integrity": "sha512-ldyueo58KjngXpzloHUog/h9REmHl59G1b3a5Sng1GfBo14BkS3ZbMEb3693gnP1k//97lh7bKsp6/V/0v1veQ==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4016,13 +3250,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.61.0.tgz",
-            "integrity": "sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.61.0",
-                "@typescript-eslint/visitor-keys": "5.61.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -4043,17 +3277,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.61.0.tgz",
-            "integrity": "sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+            "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@types/json-schema": "^7.0.9",
                 "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.61.0",
-                "@typescript-eslint/types": "5.61.0",
-                "@typescript-eslint/typescript-estree": "5.61.0",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
                 "eslint-scope": "^5.1.1",
                 "semver": "^7.3.7"
             },
@@ -4069,12 +3303,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.61.0.tgz",
-            "integrity": "sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==",
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.61.0",
+                "@typescript-eslint/types": "5.62.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -4084,6 +3318,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
         },
         "node_modules/accepts": {
             "version": "1.3.8",
@@ -4098,9 +3338,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -4119,9 +3359,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+            "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
@@ -4234,9 +3474,9 @@
             }
         },
         "node_modules/async": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
             "dev": true
         },
         "node_modules/asynckit": {
@@ -4244,7 +3484,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
-<<<<<<< HEAD
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4260,9 +3499,10 @@
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.1569.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1569.0.tgz",
-            "integrity": "sha512-9puKjesHKOjAYPqFurW/9nv3qhQ+STu3bVa5PN158SCeZPE6NsxZIWnHLglJvKU7N8UXJo1aJHmKDUGrsS7rXw==",
+            "version": "2.1574.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1574.0.tgz",
+            "integrity": "sha512-AC3VptGeggp7AFGj66PIt9GrnLyDBo7Owb5TmbGDe2OIvgeHH3nBD4S3wRZQ9u3Ea6iREnalXxQ2n5rflCeG9g==",
+            "hasInstallScript": true,
             "dependencies": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -4287,8 +3527,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/axios": {
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
@@ -4300,15 +3538,15 @@
             }
         },
         "node_modules/babel-jest": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
-            "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+            "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
             "dev": true,
             "dependencies": {
-                "@jest/transform": "^29.6.1",
+                "@jest/transform": "^29.7.0",
                 "@types/babel__core": "^7.1.14",
                 "babel-plugin-istanbul": "^6.1.1",
-                "babel-preset-jest": "^29.5.0",
+                "babel-preset-jest": "^29.6.3",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
                 "slash": "^3.0.0"
@@ -4336,10 +3574,35 @@
                 "node": ">=8"
             }
         },
+        "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.12.3",
+                "@babel/parser": "^7.14.7",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/babel-plugin-istanbul/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/babel-plugin-jest-hoist": {
-            "version": "29.5.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.5.0.tgz",
-            "integrity": "sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+            "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.3.3",
@@ -4375,12 +3638,12 @@
             }
         },
         "node_modules/babel-preset-jest": {
-            "version": "29.5.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.5.0.tgz",
-            "integrity": "sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+            "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
             "dev": true,
             "dependencies": {
-                "babel-plugin-jest-hoist": "^29.5.0",
+                "babel-plugin-jest-hoist": "^29.6.3",
                 "babel-preset-current-node-syntax": "^1.0.0"
             },
             "engines": {
@@ -4396,7 +3659,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-<<<<<<< HEAD
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4416,8 +3678,6 @@
                 }
             ]
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4428,12 +3688,12 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dependencies": {
                 "bytes": "3.1.2",
-                "content-type": "~1.0.4",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
@@ -4441,7 +3701,7 @@
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
                 "qs": "6.11.0",
-                "raw-body": "2.5.1",
+                "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
             },
@@ -4463,14 +3723,11 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
-<<<<<<< HEAD
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4494,9 +3751,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.9",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-            "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "dev": true,
             "funding": [
                 {
@@ -4513,10 +3770,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001503",
-                "electron-to-chromium": "^1.4.431",
-                "node-releases": "^2.0.12",
-                "update-browserslist-db": "^1.0.11"
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
+                "node-releases": "^2.0.14",
+                "update-browserslist-db": "^1.0.13"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -4553,7 +3810,6 @@
             "engines": {
                 "node": ">=14.20.1"
             }
-<<<<<<< HEAD
         },
         "node_modules/buffer": {
             "version": "4.9.2",
@@ -4564,8 +3820,6 @@
                 "ieee754": "^1.1.4",
                 "isarray": "^1.0.0"
             }
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -4582,7 +3836,6 @@
             }
         },
         "node_modules/call-bind": {
-<<<<<<< HEAD
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
             "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
@@ -4595,14 +3848,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-=======
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4627,9 +3872,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001513",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001513.tgz",
-            "integrity": "sha512-pnjGJo7SOOjAGytZZ203Em95MRM8Cr6jhCXNF/FAXTpCTRTECnqQWLpiTRqrFtdYcth8hf4WECUpkezuYsMVww==",
+            "version": "1.0.30001596",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
+            "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
             "dev": true,
             "funding": [
                 {
@@ -4672,16 +3917,10 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -4693,6 +3932,9 @@
             },
             "engines": {
                 "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
@@ -4711,9 +3953,9 @@
             }
         },
         "node_modules/ci-info": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-            "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
             "dev": true,
             "funding": [
                 {
@@ -4888,6 +4130,27 @@
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
         },
+        "node_modules/create-jest": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+            "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "prompts": "^2.0.1"
+            },
+            "bin": {
+                "create-jest": "bin/create-jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/create-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -4925,10 +4188,18 @@
             }
         },
         "node_modules/dedent": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-            "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
-            "dev": true
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+            "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+            "dev": true,
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -4944,7 +4215,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-<<<<<<< HEAD
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -4961,8 +4231,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -5008,9 +4276,9 @@
             }
         },
         "node_modules/diff-sequences": {
-            "version": "29.4.3",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-            "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
             "dev": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5041,15 +4309,15 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+            "version": "16.4.5",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+            "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
             "dev": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
-                "url": "https://github.com/motdotla/dotenv?sponsor=1"
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dynamic-dedupe": {
@@ -5067,9 +4335,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.453",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.453.tgz",
-            "integrity": "sha512-BU8UtQz6CB3T7RIGhId4BjmjJVXQDujb0+amGL8jpcluFJr6lwspBOvkUbnttfpZCm4zFMHmjrX1QrdPWBBMjQ==",
+            "version": "1.4.699",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.699.tgz",
+            "integrity": "sha512-I7q3BbQi6e4tJJN5CRcyvxhK0iJb34TV8eJQcgh+fR2fQ8miMgZcEInckCo1U9exDHbfz7DLDnFn8oqH/VcRKw==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -5113,7 +4381,6 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-<<<<<<< HEAD
         "node_modules/es-define-property": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -5133,8 +4400,6 @@
                 "node": ">= 0.4"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/esbuild": {
             "version": "0.18.20",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
@@ -5173,9 +4438,9 @@
             }
         },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -5199,27 +4464,28 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.44.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-            "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.1.0",
-                "@eslint/js": "8.44.0",
-                "@humanwhocodes/config-array": "^0.11.10",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.0",
-                "eslint-visitor-keys": "^3.4.1",
-                "espree": "^9.6.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -5229,7 +4495,6 @@
                 "globals": "^13.19.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
@@ -5241,7 +4506,6 @@
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0"
             },
             "bin": {
@@ -5268,9 +4532,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5280,9 +4544,9 @@
             }
         },
         "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-            "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -5305,9 +4569,9 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.9.0",
@@ -5400,7 +4664,6 @@
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "engines": {
                 "node": ">= 0.6"
-<<<<<<< HEAD
             }
         },
         "node_modules/events": {
@@ -5409,8 +4672,6 @@
             "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
             "engines": {
                 "node": ">=0.4.x"
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/execa": {
@@ -5446,30 +4707,29 @@
             }
         },
         "node_modules/expect": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.1.tgz",
-            "integrity": "sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+            "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
             "dev": true,
             "dependencies": {
-                "@jest/expect-utils": "^29.6.1",
-                "@types/node": "*",
-                "jest-get-type": "^29.4.3",
-                "jest-matcher-utils": "^29.6.1",
-                "jest-message-util": "^29.6.1",
-                "jest-util": "^29.6.1"
+                "@jest/expect-utils": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+            "version": "4.18.3",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
+            "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
+                "body-parser": "1.20.2",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.5.0",
@@ -5596,7 +4856,6 @@
             },
             "engines": {
                 "node": ">=4"
-<<<<<<< HEAD
             }
         },
         "node_modules/express/node_modules/debug": {
@@ -5607,18 +4866,6 @@
                 "ms": "2.0.0"
             }
         },
-=======
-            }
-        },
-        "node_modules/express/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/express/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5631,9 +4878,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -5670,7 +4917,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
-<<<<<<< HEAD
         "node_modules/fast-xml-parser": {
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
@@ -5692,12 +4938,10 @@
                 "fxparser": "src/cli/cli.js"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -5789,12 +5033,13 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "dependencies": {
-                "flatted": "^3.1.0",
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.3",
                 "rimraf": "^3.0.2"
             },
             "engines": {
@@ -5802,9 +5047,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true
         },
         "node_modules/fn.name": {
@@ -5831,7 +5076,6 @@
                     "optional": true
                 }
             }
-<<<<<<< HEAD
         },
         "node_modules/for-each": {
             "version": "0.3.3",
@@ -5840,8 +5084,6 @@
             "dependencies": {
                 "is-callable": "^1.1.3"
             }
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/form-data": {
             "version": "4.0.0",
@@ -5879,9 +5121,9 @@
             "dev": true
         },
         "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
@@ -5893,18 +5135,12 @@
             }
         },
         "node_modules/function-bind": {
-<<<<<<< HEAD
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-=======
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -5925,7 +5161,6 @@
             }
         },
         "node_modules/get-intrinsic": {
-<<<<<<< HEAD
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
             "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
@@ -5938,16 +5173,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-=======
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5975,9 +5200,9 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
-            "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+            "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
             "dev": true,
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -6019,9 +5244,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.20.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-            "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -6053,7 +5278,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-<<<<<<< HEAD
         "node_modules/gopd": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6065,8 +5289,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6079,21 +5301,6 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-<<<<<<< HEAD
-            "dev": true,
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6102,7 +5309,6 @@
             "engines": {
                 "node": ">=8"
             }
-<<<<<<< HEAD
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
@@ -6114,13 +5320,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6139,7 +5343,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
@@ -6163,14 +5366,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
-=======
+            }
+        },
         "node_modules/helmet": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
             "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
             "engines": {
                 "node": ">=16.0.0"
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/html-escaper": {
@@ -6214,18 +5417,15 @@
                 "node": ">=0.10.0"
             }
         },
-<<<<<<< HEAD
         "node_modules/ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -6302,11 +5502,6 @@
                 "node": ">= 12"
             }
         },
-        "node_modules/ip-address/node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
-        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6314,7 +5509,6 @@
             "engines": {
                 "node": ">= 0.10"
             }
-<<<<<<< HEAD
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
@@ -6330,8 +5524,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -6349,7 +5541,6 @@
             },
             "engines": {
                 "node": ">=8"
-<<<<<<< HEAD
             }
         },
         "node_modules/is-callable": {
@@ -6361,17 +5552,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-            "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
             "dev": true,
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6404,7 +5593,6 @@
                 "node": ">=6"
             }
         },
-<<<<<<< HEAD
         "node_modules/is-generator-function": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
@@ -6419,8 +5607,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6462,7 +5648,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-<<<<<<< HEAD
         },
         "node_modules/is-typed-array": {
             "version": "1.1.13",
@@ -6483,9 +5668,6 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
-=======
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6493,51 +5675,42 @@
             "dev": true
         },
         "node_modules/istanbul-lib-coverage": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-            "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
             "dev": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/istanbul-lib-instrument": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+            "integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
             "dev": true,
             "dependencies": {
-                "@babel/core": "^7.12.3",
-                "@babel/parser": "^7.14.7",
-                "@istanbuljs/schema": "^0.1.2",
+                "@babel/core": "^7.23.9",
+                "@babel/parser": "^7.23.9",
+                "@istanbuljs/schema": "^0.1.3",
                 "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^6.3.0"
+                "semver": "^7.5.4"
             },
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
+                "node": ">=10"
             }
         },
         "node_modules/istanbul-lib-report": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-            "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
             "dev": true,
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
-                "make-dir": "^3.0.0",
+                "make-dir": "^4.0.0",
                 "supports-color": "^7.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             }
         },
         "node_modules/istanbul-lib-source-maps": {
@@ -6555,9 +5728,9 @@
             }
         },
         "node_modules/istanbul-reports": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-            "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
             "dev": true,
             "dependencies": {
                 "html-escaper": "^2.0.0",
@@ -6568,15 +5741,15 @@
             }
         },
         "node_modules/jest": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
-            "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+            "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "dependencies": {
-                "@jest/core": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/core": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "import-local": "^3.0.2",
-                "jest-cli": "^29.6.1"
+                "jest-cli": "^29.7.0"
             },
             "bin": {
                 "jest": "bin/jest.js"
@@ -6594,12 +5767,13 @@
             }
         },
         "node_modules/jest-changed-files": {
-            "version": "29.5.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.5.0.tgz",
-            "integrity": "sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+            "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
             "dev": true,
             "dependencies": {
                 "execa": "^5.0.0",
+                "jest-util": "^29.7.0",
                 "p-limit": "^3.1.0"
             },
             "engines": {
@@ -6607,28 +5781,28 @@
             }
         },
         "node_modules/jest-circus": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.1.tgz",
-            "integrity": "sha512-tPbYLEiBU4MYAL2XoZme/bgfUeotpDBd81lgHLCbDZZFaGmECk0b+/xejPFtmiBP87GgP/y4jplcRpbH+fgCzQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+            "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.6.1",
-                "@jest/expect": "^29.6.1",
-                "@jest/test-result": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
-                "dedent": "^0.7.0",
+                "dedent": "^1.0.0",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^29.6.1",
-                "jest-matcher-utils": "^29.6.1",
-                "jest-message-util": "^29.6.1",
-                "jest-runtime": "^29.6.1",
-                "jest-snapshot": "^29.6.1",
-                "jest-util": "^29.6.1",
+                "jest-each": "^29.7.0",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
                 "p-limit": "^3.1.0",
-                "pretty-format": "^29.6.1",
+                "pretty-format": "^29.7.0",
                 "pure-rand": "^6.0.0",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
@@ -6638,22 +5812,21 @@
             }
         },
         "node_modules/jest-cli": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.1.tgz",
-            "integrity": "sha512-607dSgTA4ODIN6go9w6xY3EYkyPFGicx51a69H7yfvt7lN53xNswEVLovq+E77VsTRi5fWprLH0yl4DJgE8Ing==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+            "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
             "dev": true,
             "dependencies": {
-                "@jest/core": "^29.6.1",
-                "@jest/test-result": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/core": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "chalk": "^4.0.0",
+                "create-jest": "^29.7.0",
                 "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
                 "import-local": "^3.0.2",
-                "jest-config": "^29.6.1",
-                "jest-util": "^29.6.1",
-                "jest-validate": "^29.6.1",
-                "prompts": "^2.0.1",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
                 "yargs": "^17.3.1"
             },
             "bin": {
@@ -6672,31 +5845,31 @@
             }
         },
         "node_modules/jest-config": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.1.tgz",
-            "integrity": "sha512-XdjYV2fy2xYixUiV2Wc54t3Z4oxYPAELUzWnV6+mcbq0rh742X2p52pii5A3oeRzYjLnQxCsZmp0qpI6klE2cQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+            "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
-                "@jest/test-sequencer": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "babel-jest": "^29.6.1",
+                "@jest/test-sequencer": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "babel-jest": "^29.7.0",
                 "chalk": "^4.0.0",
                 "ci-info": "^3.2.0",
                 "deepmerge": "^4.2.2",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.9",
-                "jest-circus": "^29.6.1",
-                "jest-environment-node": "^29.6.1",
-                "jest-get-type": "^29.4.3",
-                "jest-regex-util": "^29.4.3",
-                "jest-resolve": "^29.6.1",
-                "jest-runner": "^29.6.1",
-                "jest-util": "^29.6.1",
-                "jest-validate": "^29.6.1",
+                "jest-circus": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
                 "micromatch": "^4.0.4",
                 "parse-json": "^5.2.0",
-                "pretty-format": "^29.6.1",
+                "pretty-format": "^29.7.0",
                 "slash": "^3.0.0",
                 "strip-json-comments": "^3.1.1"
             },
@@ -6717,24 +5890,24 @@
             }
         },
         "node_modules/jest-diff": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
-            "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+            "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.0.0",
-                "diff-sequences": "^29.4.3",
-                "jest-get-type": "^29.4.3",
-                "pretty-format": "^29.6.1"
+                "diff-sequences": "^29.6.3",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-docblock": {
-            "version": "29.4.3",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
-            "integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+            "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
             "dev": true,
             "dependencies": {
                 "detect-newline": "^3.0.0"
@@ -6744,62 +5917,62 @@
             }
         },
         "node_modules/jest-each": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.1.tgz",
-            "integrity": "sha512-n5eoj5eiTHpKQCAVcNTT7DRqeUmJ01hsAL0Q1SMiBHcBcvTKDELixQOGMCpqhbIuTcfC4kMfSnpmDqRgRJcLNQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+            "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "chalk": "^4.0.0",
-                "jest-get-type": "^29.4.3",
-                "jest-util": "^29.6.1",
-                "pretty-format": "^29.6.1"
+                "jest-get-type": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "pretty-format": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-environment-node": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
-            "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+            "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.6.1",
-                "@jest/fake-timers": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/environment": "^29.7.0",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
-                "jest-mock": "^29.6.1",
-                "jest-util": "^29.6.1"
+                "jest-mock": "^29.7.0",
+                "jest-util": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-get-type": {
-            "version": "29.4.3",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-            "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
             "dev": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-haste-map": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
-            "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+            "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "@types/graceful-fs": "^4.1.3",
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
                 "graceful-fs": "^4.2.9",
-                "jest-regex-util": "^29.4.3",
-                "jest-util": "^29.6.1",
-                "jest-worker": "^29.6.1",
+                "jest-regex-util": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "jest-worker": "^29.7.0",
                 "micromatch": "^4.0.4",
                 "walker": "^1.0.8"
             },
@@ -6811,46 +5984,46 @@
             }
         },
         "node_modules/jest-leak-detector": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.1.tgz",
-            "integrity": "sha512-OrxMNyZirpOEwkF3UHnIkAiZbtkBWiye+hhBweCHkVbCgyEy71Mwbb5zgeTNYWJBi1qgDVfPC1IwO9dVEeTLwQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+            "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
             "dev": true,
             "dependencies": {
-                "jest-get-type": "^29.4.3",
-                "pretty-format": "^29.6.1"
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-matcher-utils": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.1.tgz",
-            "integrity": "sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+            "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.0.0",
-                "jest-diff": "^29.6.1",
-                "jest-get-type": "^29.4.3",
-                "pretty-format": "^29.6.1"
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-message-util": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
-            "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+            "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "@types/stack-utils": "^2.0.0",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^29.6.1",
+                "pretty-format": "^29.7.0",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
             },
@@ -6859,14 +6032,14 @@
             }
         },
         "node_modules/jest-mock": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
-            "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+            "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
-                "jest-util": "^29.6.1"
+                "jest-util": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6890,26 +6063,26 @@
             }
         },
         "node_modules/jest-regex-util": {
-            "version": "29.4.3",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
-            "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+            "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
             "dev": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-resolve": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.1.tgz",
-            "integrity": "sha512-AeRkyS8g37UyJiP9w3mmI/VXU/q8l/IH52vj/cDAyScDcemRbSBhfX/NMYIGilQgSVwsjxrCHf3XJu4f+lxCMg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+            "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.6.1",
+                "jest-haste-map": "^29.7.0",
                 "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^29.6.1",
-                "jest-validate": "^29.6.1",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
                 "resolve": "^1.20.0",
                 "resolve.exports": "^2.0.0",
                 "slash": "^3.0.0"
@@ -6919,43 +6092,43 @@
             }
         },
         "node_modules/jest-resolve-dependencies": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.1.tgz",
-            "integrity": "sha512-BbFvxLXtcldaFOhNMXmHRWx1nXQO5LoXiKSGQcA1LxxirYceZT6ch8KTE1bK3X31TNG/JbkI7OkS/ABexVahiw==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+            "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
             "dev": true,
             "dependencies": {
-                "jest-regex-util": "^29.4.3",
-                "jest-snapshot": "^29.6.1"
+                "jest-regex-util": "^29.6.3",
+                "jest-snapshot": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-runner": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.1.tgz",
-            "integrity": "sha512-tw0wb2Q9yhjAQ2w8rHRDxteryyIck7gIzQE4Reu3JuOBpGp96xWgF0nY8MDdejzrLCZKDcp8JlZrBN/EtkQvPQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+            "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
             "dev": true,
             "dependencies": {
-                "@jest/console": "^29.6.1",
-                "@jest/environment": "^29.6.1",
-                "@jest/test-result": "^29.6.1",
-                "@jest/transform": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/console": "^29.7.0",
+                "@jest/environment": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "emittery": "^0.13.1",
                 "graceful-fs": "^4.2.9",
-                "jest-docblock": "^29.4.3",
-                "jest-environment-node": "^29.6.1",
-                "jest-haste-map": "^29.6.1",
-                "jest-leak-detector": "^29.6.1",
-                "jest-message-util": "^29.6.1",
-                "jest-resolve": "^29.6.1",
-                "jest-runtime": "^29.6.1",
-                "jest-util": "^29.6.1",
-                "jest-watcher": "^29.6.1",
-                "jest-worker": "^29.6.1",
+                "jest-docblock": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-leak-detector": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-resolve": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-watcher": "^29.7.0",
+                "jest-worker": "^29.7.0",
                 "p-limit": "^3.1.0",
                 "source-map-support": "0.5.13"
             },
@@ -6964,31 +6137,31 @@
             }
         },
         "node_modules/jest-runtime": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.1.tgz",
-            "integrity": "sha512-D6/AYOA+Lhs5e5il8+5pSLemjtJezUr+8zx+Sn8xlmOux3XOqx4d8l/2udBea8CRPqqrzhsKUsN/gBDE/IcaPQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+            "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.6.1",
-                "@jest/fake-timers": "^29.6.1",
-                "@jest/globals": "^29.6.1",
-                "@jest/source-map": "^29.6.0",
-                "@jest/test-result": "^29.6.1",
-                "@jest/transform": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/environment": "^29.7.0",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/globals": "^29.7.0",
+                "@jest/source-map": "^29.6.3",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "cjs-module-lexer": "^1.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.6.1",
-                "jest-message-util": "^29.6.1",
-                "jest-mock": "^29.6.1",
-                "jest-regex-util": "^29.4.3",
-                "jest-resolve": "^29.6.1",
-                "jest-snapshot": "^29.6.1",
-                "jest-util": "^29.6.1",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-mock": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0"
             },
@@ -6997,9 +6170,9 @@
             }
         },
         "node_modules/jest-snapshot": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.1.tgz",
-            "integrity": "sha512-G4UQE1QQ6OaCgfY+A0uR1W2AY0tGXUPQpoUClhWHq1Xdnx1H6JOrC2nH5lqnOEqaDgbHFgIwZ7bNq24HpB180A==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+            "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
@@ -7007,21 +6180,20 @@
                 "@babel/plugin-syntax-jsx": "^7.7.2",
                 "@babel/plugin-syntax-typescript": "^7.7.2",
                 "@babel/types": "^7.3.3",
-                "@jest/expect-utils": "^29.6.1",
-                "@jest/transform": "^29.6.1",
-                "@jest/types": "^29.6.1",
-                "@types/prettier": "^2.1.5",
+                "@jest/expect-utils": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "babel-preset-current-node-syntax": "^1.0.0",
                 "chalk": "^4.0.0",
-                "expect": "^29.6.1",
+                "expect": "^29.7.0",
                 "graceful-fs": "^4.2.9",
-                "jest-diff": "^29.6.1",
-                "jest-get-type": "^29.4.3",
-                "jest-matcher-utils": "^29.6.1",
-                "jest-message-util": "^29.6.1",
-                "jest-util": "^29.6.1",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^29.6.1",
+                "pretty-format": "^29.7.0",
                 "semver": "^7.5.3"
             },
             "engines": {
@@ -7029,12 +6201,12 @@
             }
         },
         "node_modules/jest-util": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-            "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "ci-info": "^3.2.0",
@@ -7046,17 +6218,17 @@
             }
         },
         "node_modules/jest-validate": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.1.tgz",
-            "integrity": "sha512-r3Ds69/0KCN4vx4sYAbGL1EVpZ7MSS0vLmd3gV78O+NAx3PDQQukRU5hNHPXlyqCgFY8XUk7EuTMLugh0KzahA==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+            "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.6.1",
+                "@jest/types": "^29.6.3",
                 "camelcase": "^6.2.0",
                 "chalk": "^4.0.0",
-                "jest-get-type": "^29.4.3",
+                "jest-get-type": "^29.6.3",
                 "leven": "^3.1.0",
-                "pretty-format": "^29.6.1"
+                "pretty-format": "^29.7.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7075,18 +6247,18 @@
             }
         },
         "node_modules/jest-watcher": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.1.tgz",
-            "integrity": "sha512-d4wpjWTS7HEZPaaj8m36QiaP856JthRZkrgcIY/7ISoUWPIillrXM23WPboZVLbiwZBt4/qn2Jke84Sla6JhFA==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+            "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
             "dev": true,
             "dependencies": {
-                "@jest/test-result": "^29.6.1",
-                "@jest/types": "^29.6.1",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
                 "emittery": "^0.13.1",
-                "jest-util": "^29.6.1",
+                "jest-util": "^29.7.0",
                 "string-length": "^4.0.1"
             },
             "engines": {
@@ -7094,13 +6266,13 @@
             }
         },
         "node_modules/jest-worker": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
-            "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "jest-util": "^29.6.1",
+                "jest-util": "^29.7.0",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^8.0.0"
             },
@@ -7121,7 +6293,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-<<<<<<< HEAD
             }
         },
         "node_modules/jmespath": {
@@ -7130,8 +6301,6 @@
             "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
             "engines": {
                 "node": ">= 0.6.0"
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/js-tokens": {
@@ -7169,6 +6338,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
+        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7205,6 +6380,15 @@
             "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "dependencies": {
+                "json-buffer": "3.0.1"
             }
         },
         "node_modules/kleur": {
@@ -7284,17 +6468,20 @@
             "dev": true
         },
         "node_modules/logform": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
-            "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+            "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
             "dev": true,
             "dependencies": {
-                "@colors/colors": "1.5.0",
+                "@colors/colors": "1.6.0",
                 "@types/triple-beam": "^1.3.2",
                 "fecha": "^4.2.0",
                 "ms": "^2.1.1",
                 "safe-stable-stringify": "^2.3.1",
                 "triple-beam": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/lru-cache": {
@@ -7307,27 +6494,18 @@
             }
         },
         "node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
             "dev": true,
             "dependencies": {
-                "semver": "^6.0.0"
+                "semver": "^7.5.3"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/make-error": {
@@ -7603,8 +6781,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-<<<<<<< HEAD
-=======
         },
         "node_modules/nocache": {
             "version": "4.0.0",
@@ -7613,7 +6789,6 @@
             "engines": {
                 "node": ">=16.0.0"
             }
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
@@ -7622,9 +6797,9 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -7649,9 +6824,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -7918,7 +7093,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-<<<<<<< HEAD
             }
         },
         "node_modules/pkg-dir/node_modules/p-locate": {
@@ -7933,32 +7107,18 @@
                 "node": ">=8"
             }
         },
-=======
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/plimit-lit": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.5.0.tgz",
-            "integrity": "sha512-Eb/MqCb1Iv/ok4m1FqIXqvUKPISufcjZ605hl3KM/n8GaX8zfhtgdLwZU3vKjuHGh2O9Rjog/bHTq8ofIShdng==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+            "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
             "dev": true,
             "dependencies": {
-                "queue-lit": "^1.5.0"
+                "queue-lit": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
-<<<<<<< HEAD
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -7968,9 +7128,9 @@
             }
         },
         "node_modules/postgres": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.2.tgz",
-            "integrity": "sha512-0UcCGvDBSaAzLeWwiq+QVmiGfOPTosFb+sxJUUtd+7Pi/ByFPuz6Gq05LbS0sM1ghMWC5atuks3pfl34g0qmFw==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.3.tgz",
+            "integrity": "sha512-iHJn4+M9vbTdHSdDzNkC0crHq+1CUdFhx+YqCE+SqWxPjm+Zu63jq7yZborOBF64c8pc58O5uMudyL1FQcHacA==",
             "engines": {
                 "node": ">=12"
             },
@@ -7979,20 +7139,6 @@
                 "url": "https://github.com/sponsors/porsager"
             }
         },
-=======
-        "node_modules/postgres": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.2.tgz",
-            "integrity": "sha512-0UcCGvDBSaAzLeWwiq+QVmiGfOPTosFb+sxJUUtd+7Pi/ByFPuz6Gq05LbS0sM1ghMWC5atuks3pfl34g0qmFw==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://github.com/sponsors/porsager"
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8003,12 +7149,12 @@
             }
         },
         "node_modules/pretty-format": {
-            "version": "29.6.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-            "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
             "dependencies": {
-                "@jest/schemas": "^29.6.0",
+                "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
                 "react-is": "^18.0.0"
             },
@@ -8059,17 +7205,17 @@
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/pure-rand": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
-            "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+            "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
             "dev": true,
             "funding": [
                 {
@@ -8096,7 +7242,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-<<<<<<< HEAD
         "node_modules/querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -8106,13 +7251,14 @@
                 "node": ">=0.4.x"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/queue-lit": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.0.tgz",
-            "integrity": "sha512-IslToJ4eiCEE9xwMzq3viOO5nH8sUWUCwoElrhNMozzr9IIt2qqvB4I+uHu/zJTQVqc9R5DFwok4ijNK1pU3fA==",
-            "dev": true
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+            "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -8143,9 +7289,9 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
@@ -8198,12 +7344,12 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.11.0",
+                "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -8343,33 +7489,15 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
-<<<<<<< HEAD
-        "node_modules/saslprep": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-            "optional": true,
-            "dependencies": {
-                "sparse-bitfield": "^3.0.3"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-<<<<<<< HEAD
         "node_modules/sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
-=======
->>>>>>> chore: ajusta vulnerabilidades apontadas no npm
         "node_modules/semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -8452,7 +7580,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-<<<<<<< HEAD
             }
         },
         "node_modules/set-function-length": {
@@ -8469,8 +7596,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/setprototypeof": {
@@ -8500,13 +7625,17 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -8604,12 +7733,10 @@
             }
         },
         "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
-<<<<<<< HEAD
         "node_modules/sqs-consumer": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/sqs-consumer/-/sqs-consumer-8.2.0.tgz",
@@ -8625,8 +7752,6 @@
                 "@aws-sdk/client-sqs": "^3.447.0"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -8646,7 +7771,6 @@
             },
             "engines": {
                 "node": ">=10"
-<<<<<<< HEAD
             }
         },
         "node_modules/stack-utils/node_modules/escape-string-regexp": {
@@ -8658,19 +7782,6 @@
                 "node": ">=8"
             }
         },
-=======
-            }
-        },
-        "node_modules/stack-utils/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/statuses": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -8756,14 +7867,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-<<<<<<< HEAD
         },
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
             "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -8790,9 +7898,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.1.0.tgz",
-            "integrity": "sha512-c1KmAjuVODxw+vwkNLALQZrgdlBAuBbr2xSPfYrJgseEi7gFKcTvShysPmyuDI4kcUa1+5rFpjWvXdusKY74mg=="
+            "version": "5.11.10",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.11.10.tgz",
+            "integrity": "sha512-wAHf32iFqJCBkdQRBYB1pR8kJuliJbgCXcdgkU7GkDvrOfD2gVmyEwdTi9rERCur/OrufifnH5UecOzlQ07CYg=="
         },
         "node_modules/swagger-ui-express": {
             "version": "4.6.3",
@@ -8890,15 +7998,18 @@
             }
         },
         "node_modules/triple-beam": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-            "dev": true
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+            "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14.0.0"
+            }
         },
         "node_modules/ts-jest": {
-            "version": "29.1.1",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
-            "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
+            "version": "29.1.2",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+            "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
             "dev": true,
             "dependencies": {
                 "bs-logger": "0.x",
@@ -8914,7 +8025,7 @@
                 "ts-jest": "cli.js"
             },
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
             },
             "peerDependencies": {
                 "@babel/core": ">=7.0.0-beta.0 <8",
@@ -8939,9 +8050,9 @@
             }
         },
         "node_modules/ts-node": {
-            "version": "10.9.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
@@ -9028,9 +8139,9 @@
             }
         },
         "node_modules/tsc-alias": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.7.tgz",
-            "integrity": "sha512-59Q/zUQa3miTf99mLbSqaW0hi1jt4WoG8Uhe5hSZJHQpSoFW9eEwvW7jlKMHXWvT+zrzy3SN9PE/YBhQ+WVydA==",
+            "version": "1.8.8",
+            "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.8.tgz",
+            "integrity": "sha512-OYUOd2wl0H858NvABWr/BoSKNERw3N9GTi3rHPK8Iv4O1UyUXIrTTOAZNHsjlVpXFOhpJBVARI1s+rzwLivN3Q==",
             "dev": true,
             "dependencies": {
                 "chokidar": "^3.5.3",
@@ -9098,9 +8209,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -9117,6 +8228,12 @@
                 "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
             }
         },
+        "node_modules/tsutils/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
         "node_modules/tsx": {
             "version": "3.14.0",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
@@ -9132,20 +8249,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"
-            }
-        },
-        "node_modules/tsx/node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/tsx/node_modules/source-map-support": {
@@ -9204,9 +8307,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+            "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -9215,6 +8318,11 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
@@ -9225,9 +8333,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "dev": true,
             "funding": [
                 {
@@ -9263,7 +8371,6 @@
                 "punycode": "^2.1.0"
             }
         },
-<<<<<<< HEAD
         "node_modules/url": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -9290,8 +8397,6 @@
                 "which-typed-array": "^1.1.2"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9306,7 +8411,6 @@
                 "node": ">= 0.4.0"
             }
         },
-<<<<<<< HEAD
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -9315,8 +8419,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -9324,24 +8426,18 @@
             "dev": true
         },
         "node_modules/v8-to-istanbul": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-            "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
-                "convert-source-map": "^1.6.0"
+                "convert-source-map": "^2.0.0"
             },
             "engines": {
                 "node": ">=10.12.0"
             }
-        },
-        "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "dev": true
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -9393,7 +8489,6 @@
             },
             "engines": {
                 "node": ">= 8"
-<<<<<<< HEAD
             }
         },
         "node_modules/which-typed-array": {
@@ -9412,17 +8507,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/winston": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.9.0.tgz",
-            "integrity": "sha512-jW51iW/X95BCW6MMtZWr2jKQBP4hV5bIDq9QrIjfDk6Q9QuxvTKEAlpUNAzP+HYHFFCeENhph16s0zEunu4uuQ==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.12.0.tgz",
+            "integrity": "sha512-OwbxKaOlESDi01mC9rkM0dQqQt2I8DAUMRLZ/HpbwvDXm85IryEHgoogy5fziQy38PntgZsLlhAYHz//UPHZ5w==",
             "dev": true,
             "dependencies": {
-                "@colors/colors": "1.5.0",
+                "@colors/colors": "^1.6.0",
                 "@dabh/diagnostics": "^2.0.2",
                 "async": "^3.2.3",
                 "is-stream": "^2.0.0",
@@ -9432,16 +8525,16 @@
                 "safe-stable-stringify": "^2.3.1",
                 "stack-trace": "0.0.x",
                 "triple-beam": "^1.3.0",
-                "winston-transport": "^4.5.0"
+                "winston-transport": "^4.7.0"
             },
             "engines": {
                 "node": ">= 12.0.0"
             }
         },
         "node_modules/winston-transport": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-            "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+            "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
             "dev": true,
             "dependencies": {
                 "logform": "^2.3.2",
@@ -9449,7 +8542,7 @@
                 "triple-beam": "^1.3.0"
             },
             "engines": {
-                "node": ">= 6.4.0"
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/wrap-ansi": {
@@ -9486,7 +8579,6 @@
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-<<<<<<< HEAD
             }
         },
         "node_modules/xml2js": {
@@ -9507,8 +8599,6 @@
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "engines": {
                 "node": ">=4.0"
-=======
->>>>>>> chore: corrige alertas apontados no OWASP ZAP
             }
         },
         "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
         "axios": "^1.5.0",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
+        "helmet": "^7.1.0",
         "mongoose": "^7.2.3",
+        "nocache": "^4.0.0",
         "postgres": "^3.4.2",
         "sqs-consumer": "^8.2.0",
         "swagger-ui-express": "^4.6.3"

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,4 +1,6 @@
 import express from "express";
+import helmet from "helmet";
+import nocache from "nocache";
 import { serve, setup } from "swagger-ui-express";
 import { createMongoConnection } from "external/mongo";
 import { errorHandler } from "./middlewares";
@@ -6,6 +8,7 @@ import { makeServerRouter } from "./routes";
 import { requestLogger } from "../utils/requestLogger";
 import { SwaggerConfig } from "./docs";
 import { confirmacaoPagamentoConsumer } from "external/queueService";
+import { serverConfig } from "config";
 
 require("dotenv").config();
 
@@ -13,6 +16,19 @@ function buildServer() {
     createMongoConnection();
 
     const server = express();
+
+    server.disable("x-powered-by");
+    server.use(helmet());
+    server.use(nocache());
+
+    if (serverConfig.isProduction) {
+        server.use(
+            helmet.hsts({
+                maxAge: 31536000,
+                includeSubDomains: true,
+            }),
+        );
+    }
 
     server.use(requestLogger);
 


### PR DESCRIPTION
- Desabilita "x-powered-by"
- Adiciona lib Helmet que tem os middlewares que o OWASP apontou 
   - sobre o helmet, teoricamente precisa configurar o helmet.hsts porém o GPT respondeu isso:
       _Lembre-se de que o uso do HSTS é recomendado apenas se você estiver servindo seu site exclusivamente via HTTPS. Se você 
       ainda suporta HTTP, não ative essa configuração, pois isso pode impedir que os usuários acessem seu site._ (coloquei na config apenas para quando está em produção que vai ser HTTPS)
       
- Adiciona lib nocache para configurar o header Cache-Control
- Corrige dependências apontadas como vulnerabildades no npm

links uteis: 
https://expressjs.com/en/advanced/best-practice-security.html
https://blog.logrocket.com/using-helmet-node-js-secure-application/
https://retz.dev/blog/setting-security-headers-for-web-app:-nginx-express-and-react.
https://cheatsheetseries.owasp.org/cheatsheets/Nodejs_Security_Cheat_Sheet.html